### PR TITLE
fix: derive acting user from JWT across controllers (authorization sweep)

### DIFF
--- a/GymMaket/GymMarket.API.Tests/ConversationIntegrationTests.cs
+++ b/GymMaket/GymMarket.API.Tests/ConversationIntegrationTests.cs
@@ -15,38 +15,13 @@ public class ConversationIntegrationTests : BaseIntegrationTests
     [Fact]
     public async Task CreateConversation_WithValidData_ReturnsSuccess()
     {
-        // Arrange
+        // Arrange — the sender is the authenticated caller; only the receiver is sent.
         await AuthenticateAsync();
-        var senderEmail = "sender@example.com";
-        var receiverEmail = "receiver@example.com";
-        var password = "Password123";
-
-        // Sign up sender
-        var senderResp = await Client.PostAsJsonAsync("/api/Accounts/sign-up", new SignUpDto
-        {
-            FullName = "Sender",
-            Email = senderEmail,
-            Password = password,
-            ConfirmPassword = password,
-            Role = "Student"
-        });
-        var senderData = await senderResp.Content.ReadFromJsonAsync<SignupResponseDto>();
-
-        // Sign up receiver
-        var receiverResp = await Client.PostAsJsonAsync("/api/Accounts/sign-up", new SignUpDto
-        {
-            FullName = "Receiver",
-            Email = receiverEmail,
-            Password = password,
-            ConfirmPassword = password,
-            Role = "Student"
-        });
-        var receiverData = await receiverResp.Content.ReadFromJsonAsync<SignupResponseDto>();
+        var receiverData = await SignUpAsync("receiver@example.com", "Receiver");
 
         var model = new CreateConversationDto
         {
-            SenderId = senderData!.UserId!,
-            RecieveId = receiverData!.UserId!
+            RecieveId = receiverData.UserId!
         };
 
         // Act
@@ -59,13 +34,53 @@ public class ConversationIntegrationTests : BaseIntegrationTests
     [Fact]
     public async Task GetConversationOfUser_ReturnsOk()
     {
-        // Arrange
+        // Arrange — the user is derived from the JWT, not the route.
         await AuthenticateAsync();
 
         // Act
-        var response = await Client.GetAsync("/api/Conversations/get-conversation-of-user/user1");
+        var response = await Client.GetAsync("/api/Conversations/get-conversation-of-user");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetMessages_NonMember_ReturnsForbidden()
+    {
+        // Arrange — the authenticated user starts a conversation with a second user.
+        await AuthenticateAsync();
+        var receiverData = await SignUpAsync("receiver2@example.com", "Receiver Two");
+        await Client.PostAsJsonAsync("/api/Conversations/create-conversation", new CreateConversationDto
+        {
+            RecieveId = receiverData.UserId!
+        });
+        var conversations = await Client.GetFromJsonAsync<List<ConversationDto>>("/api/Conversations/get-conversation-of-user");
+        var conversationId = conversations!.First().ConversationId;
+
+        // Act — an outsider tries to read the messages.
+        await AuthenticateAsync(email: "outsider@example.com");
+        var response = await Client.GetAsync($"/api/Conversations/get-messages/{conversationId}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+
+        // Members can still read them.
+        await AuthenticateAsync();
+        var memberResponse = await Client.GetAsync($"/api/Conversations/get-messages/{conversationId}");
+        Assert.Equal(HttpStatusCode.OK, memberResponse.StatusCode);
+    }
+
+    private async Task<SignupResponseDto> SignUpAsync(string email, string fullName)
+    {
+        var password = "Password123";
+        var resp = await Client.PostAsJsonAsync("/api/Accounts/sign-up", new SignUpDto
+        {
+            FullName = fullName,
+            Email = email,
+            Password = password,
+            ConfirmPassword = password,
+            Role = "Student"
+        });
+        return (await resp.Content.ReadFromJsonAsync<SignupResponseDto>())!;
     }
 }

--- a/GymMaket/GymMarket.API.Tests/CourseRegistrationIntegrationTests.cs
+++ b/GymMaket/GymMarket.API.Tests/CourseRegistrationIntegrationTests.cs
@@ -1,9 +1,8 @@
 using System.Net;
 using System.Net.Http.Json;
-using GymMarket.API.DTOs.Account;
 using GymMarket.API.DTOs.Course;
 using GymMarket.API.DTOs.CourseRegistration;
-using GymMarket.API.DTOs.Student;
+using GymMarket.API.Models;
 using Microsoft.AspNetCore.Mvc.Testing;
 
 namespace GymMarket.API.Tests;
@@ -15,36 +14,10 @@ public class CourseRegistrationIntegrationTests : BaseIntegrationTests
     }
 
     [Fact]
-    public async Task RegisterCourse_WithValidData_ReturnsSuccess()
+    public async Task RegisterCourse_WithValidData_RegistersTheAuthenticatedStudent()
     {
-        // Arrange
-        await AuthenticateAsync();
-
-        // 1. Create a Student
-        var studentEmail = "student_reg@example.com";
-        var password = "Password123";
-        var signupResp = await Client.PostAsJsonAsync("/api/Accounts/sign-up", new SignUpDto
-        {
-            FullName = "Reg Student",
-            Email = studentEmail,
-            Password = password,
-            ConfirmPassword = password,
-            Role = "Student"
-        });
-        var signupData = await signupResp.Content.ReadFromJsonAsync<SignupResponseDto>();
-        var userId = signupData!.UserId;
-
-        var studentCreate = new StudentCreateDTO
-        {
-            UserId = userId,
-            Name = "Reg Student",
-            Email = studentEmail,
-            Password = password,
-            HealthStatus = "Healthy"
-        };
-        await Client.PostAsJsonAsync("/api/Student", studentCreate);
-
-        // 2. Create a Course
+        // Arrange — a trainer creates the course…
+        await AuthenticateAsync(email: "reg_trainer@example.com", role: "Trainer");
         var courseCreate = new CourseCreateDTO
         {
             CourseId = "CRS_REG_001",
@@ -55,11 +28,12 @@ public class CourseRegistrationIntegrationTests : BaseIntegrationTests
         };
         await Client.PostAsJsonAsync("/api/Course", courseCreate);
 
-        // 3. Register
+        // …and a student registers for it. The student id comes from the JWT,
+        // not the request body.
+        await AuthenticateAsync(email: "student_reg@example.com");
         var registerDto = new RegisterCourseDto
         {
-            CourseId = "CRS_REG_001",
-            StudentId = "STU_001"
+            CourseId = "CRS_REG_001"
         };
 
         // Act
@@ -67,5 +41,62 @@ public class CourseRegistrationIntegrationTests : BaseIntegrationTests
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<RegisterCourseResponseDto>();
+        Assert.Equal(GetTokenClaim("studentId"), body!.Registration!.StudentId);
+    }
+
+    [Fact]
+    public async Task RegisterCourse_AsTrainer_ReturnsForbidden()
+    {
+        // Arrange — trainers have no studentId claim, so they cannot register.
+        await AuthenticateAsync(email: "reg_trainer2@example.com", role: "Trainer");
+
+        // Act
+        var response = await Client.PostAsJsonAsync("/api/CourseRegistration/register-course", new RegisterCourseDto
+        {
+            CourseId = "CRS_REG_001"
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetCourseRegistrations_ReturnsOnlyOwnRegistrations()
+    {
+        // Arrange — a trainer creates a course and student A registers for it.
+        await AuthenticateAsync(email: "reg_trainer3@example.com", role: "Trainer");
+        await Client.PostAsJsonAsync("/api/Course", new CourseCreateDTO
+        {
+            CourseId = "CRS_REG_002",
+            Title = "Isolation Test Course",
+            StartDate = DateTime.Now.AddDays(1),
+            EndDate = DateTime.Now.AddDays(30),
+            Price = 50
+        });
+
+        await AuthenticateAsync(email: "student_a@example.com");
+        await Client.PostAsJsonAsync("/api/CourseRegistration/register-course", new RegisterCourseDto
+        {
+            CourseId = "CRS_REG_002"
+        });
+
+        // Act — student B asks for their registrations (the id comes from the JWT).
+        await AuthenticateAsync(email: "student_b@example.com");
+        var coursesOfB = await Client.GetFromJsonAsync<List<GetCourseDto>>("/api/CourseRegistration/get-course-registrations");
+
+        // Assert — student A's registration is not visible to student B.
+        Assert.NotNull(coursesOfB);
+        Assert.Empty(coursesOfB!);
+
+        await AuthenticateAsync(email: "student_a@example.com");
+        var coursesOfA = await Client.GetFromJsonAsync<List<GetCourseDto>>("/api/CourseRegistration/get-course-registrations");
+        Assert.Single(coursesOfA!);
+    }
+
+    private class RegisterCourseResponseDto
+    {
+        public string? Message { get; set; }
+        public CourseRegistration? Registration { get; set; }
     }
 }

--- a/GymMaket/GymMarket.API.Tests/FoodNutritionIntegrationTests.cs
+++ b/GymMaket/GymMarket.API.Tests/FoodNutritionIntegrationTests.cs
@@ -1,7 +1,10 @@
 using System.Net;
 using System.Net.Http.Json;
+using GymMarket.API.Data;
 using GymMarket.API.DTOs.FoodNutritionUser;
+using GymMarket.API.Models;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace GymMarket.API.Tests;
 
@@ -31,7 +34,7 @@ public class FoodNutritionIntegrationTests : BaseIntegrationTests
         await AuthenticateAsync();
 
         // Act
-        var response = await Client.GetAsync("/api/FoodNutrition/get-nutrition-user/user1");
+        var response = await Client.GetAsync("/api/FoodNutrition/get-nutrition-user");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -44,7 +47,6 @@ public class FoodNutritionIntegrationTests : BaseIntegrationTests
         await AuthenticateAsync();
         var model = new AddFoodNutritionUser
         {
-            UserId = "user1",
             FoodNutritionId = 1,
             FoodName = "Apple",
             Weight = 100,
@@ -59,5 +61,134 @@ public class FoodNutritionIntegrationTests : BaseIntegrationTests
         // Assert
         // This might fail if the ID 1 doesn't exist, but we are testing the API endpoint reachability and basic logic
         Assert.True(response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task CalCaloricValue_PersistsDateAndMealType()
+    {
+        // Arrange
+        await AuthenticateAsync();
+        var foodId = await SeedFoodAsync();
+        var model = new AddFoodNutritionUser
+        {
+            FoodNutritionId = foodId,
+            FoodName = "Apple",
+            Weight = 200,
+            Date = new DateOnly(2026, 6, 12),
+            MealType = "Lunch"
+        };
+
+        // Act
+        var response = await Client.PostAsJsonAsync("/api/FoodNutrition/cal-caloric-value", model);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var created = await response.Content.ReadFromJsonAsync<FoodNutritionUser>();
+        Assert.NotNull(created);
+        Assert.Equal(new DateOnly(2026, 6, 12), created!.Date);
+        Assert.Equal("Lunch", created.MealType);
+        Assert.Equal(104, created.CaloricValue); // 52 kcal/100g * 200g
+        Assert.Equal(GetTokenClaim("nameid"), created.UserId); // owner comes from the JWT
+    }
+
+    [Fact]
+    public async Task UpdateFoodNutritionUser_RescalesMacrosAndUpdatesMealType()
+    {
+        // Arrange
+        await AuthenticateAsync();
+        var foodId = await SeedFoodAsync();
+        var createResponse = await Client.PostAsJsonAsync("/api/FoodNutrition/cal-caloric-value", new AddFoodNutritionUser
+        {
+            FoodNutritionId = foodId,
+            FoodName = "Apple",
+            Weight = 100,
+            Date = new DateOnly(2026, 6, 12),
+            MealType = "Breakfast"
+        });
+        var created = await createResponse.Content.ReadFromJsonAsync<FoodNutritionUser>();
+
+        // Act
+        var response = await Client.PutAsJsonAsync("/api/FoodNutrition/update-foodnutrition-user", new UpdateFoodNutritionUserDto
+        {
+            FoodNutritionUserId = created!.Id,
+            Weight = 300,
+            Date = new DateOnly(2026, 6, 13),
+            MealType = "Dinner"
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var updated = await response.Content.ReadFromJsonAsync<FoodNutritionUser>();
+        Assert.NotNull(updated);
+        Assert.Equal(300, updated!.Weight);
+        Assert.Equal(156, updated.CaloricValue); // 52 kcal/100g * 300g
+        Assert.Equal(0.9, updated.Protein, 5);   // 0.3 g/100g * 300g
+        Assert.Equal(new DateOnly(2026, 6, 13), updated.Date);
+        Assert.Equal("Dinner", updated.MealType);
+    }
+
+    [Fact]
+    public async Task UpdateFoodNutritionUser_AnotherUsersLog_ReturnsBadRequest()
+    {
+        // Arrange — owner logs an entry
+        await AuthenticateAsync();
+        var foodId = await SeedFoodAsync();
+        var createResponse = await Client.PostAsJsonAsync("/api/FoodNutrition/cal-caloric-value", new AddFoodNutritionUser
+        {
+            FoodNutritionId = foodId,
+            FoodName = "Apple",
+            Weight = 100
+        });
+        var created = await createResponse.Content.ReadFromJsonAsync<FoodNutritionUser>();
+
+        // Act — a different authenticated user tries to update it
+        await AuthenticateAsync(email: "attacker@example.com");
+        var response = await Client.PutAsJsonAsync("/api/FoodNutrition/update-foodnutrition-user", new UpdateFoodNutritionUserDto
+        {
+            FoodNutritionUserId = created!.Id,
+            Weight = 300
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteFoodNutritionUser_WithBody_ReturnsOk()
+    {
+        // Arrange
+        await AuthenticateAsync();
+        var foodId = await SeedFoodAsync();
+        var createResponse = await Client.PostAsJsonAsync("/api/FoodNutrition/cal-caloric-value", new AddFoodNutritionUser
+        {
+            FoodNutritionId = foodId,
+            FoodName = "Apple",
+            Weight = 100
+        });
+        var created = await createResponse.Content.ReadFromJsonAsync<FoodNutritionUser>();
+
+        // Act — the Angular client sends DELETE with a JSON body
+        var request = new HttpRequestMessage(HttpMethod.Delete, "/api/FoodNutrition/delete-foodnutrition-user")
+        {
+            Content = JsonContent.Create(new DeleteFoodNutritionUserDto
+            {
+                FoodNutritionUserId = created!.Id
+            })
+        };
+        var response = await Client.SendAsync(request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    // The in-memory test database never runs migrations/HasData, so seed a food row directly.
+    private async Task<int> SeedFoodAsync()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<GymMarketContext>();
+        var food = new FoodNutrition { Name = "Apple", CaloricValue = 52, Fat = 0.2, Sugars = 10.4, Protein = 0.3 };
+        context.FoodNutritions.Add(food);
+        await context.SaveChangesAsync();
+        return food.Id;
     }
 }

--- a/GymMaket/GymMarket.API.Tests/PaymentsAuthorizationTests.cs
+++ b/GymMaket/GymMarket.API.Tests/PaymentsAuthorizationTests.cs
@@ -1,0 +1,150 @@
+using System.Net;
+using System.Net.Http.Json;
+using GymMarket.API.Data;
+using GymMarket.API.DTOs.Course;
+using GymMarket.API.DTOs.Payment;
+using GymMarket.API.Models;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GymMarket.API.Tests;
+
+// Locks in the ownership rules for payment management and course updates:
+// a trainer may only act on courses (and their payments) that they own.
+public class PaymentsAuthorizationTests : BaseIntegrationTests
+{
+    public PaymentsAuthorizationTests(WebApplicationFactory<Program> factory) : base(factory)
+    {
+    }
+
+    [Fact]
+    public async Task GetPaymentsOfCourse_OtherTrainersCourse_ReturnsForbidden()
+    {
+        // Arrange — trainer A owns the course.
+        var courseId = await CreateOwnedCourseAsync("payments_owner@example.com");
+
+        // Act — trainer B asks for its payments.
+        await AuthenticateAsync(email: "payments_other@example.com", role: "Trainer");
+        var response = await Client.GetAsync($"/api/Payments/get-payments-of-course/{courseId}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+
+        // The owner can still read them.
+        await AuthenticateAsync(email: "payments_owner@example.com", role: "Trainer");
+        var ownerResponse = await Client.GetAsync($"/api/Payments/get-payments-of-course/{courseId}");
+        Assert.Equal(HttpStatusCode.OK, ownerResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task OkPayment_OtherTrainersCourse_ReturnsForbidden()
+    {
+        // Arrange — a pending payment exists on trainer A's course.
+        var courseId = await CreateOwnedCourseAsync("okpay_owner@example.com");
+        var paymentId = await SeedPendingPaymentAsync(courseId);
+
+        // Act — trainer B tries to approve it.
+        await AuthenticateAsync(email: "okpay_other@example.com", role: "Trainer");
+        var response = await Client.PostAsync($"/api/Payments/ok-payment/{paymentId}", null);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CancelPayment_OtherTrainersCourse_ReturnsForbidden()
+    {
+        // Arrange
+        var courseId = await CreateOwnedCourseAsync("cancelpay_owner@example.com");
+        var paymentId = await SeedPendingPaymentAsync(courseId);
+
+        // Act
+        await AuthenticateAsync(email: "cancelpay_other@example.com", role: "Trainer");
+        var response = await Client.PostAsJsonAsync("/api/Payments/cancel-payment", new CancelPayment
+        {
+            PaymentId = paymentId,
+            Note = "trying to cancel someone else's payment"
+        });
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task UpdateCourse_OtherTrainersCourse_ReturnsForbidden()
+    {
+        // Arrange — trainer A owns the course.
+        var courseId = await CreateOwnedCourseAsync("update_owner@example.com");
+
+        // Act — trainer B tries to update it (multipart, like the Angular client).
+        await AuthenticateAsync(email: "update_other@example.com", role: "Trainer");
+        using var form = new MultipartFormDataContent
+        {
+            { new StringContent(courseId), "CourseId" },
+            { new StringContent("Hijacked Title"), "Title" }
+        };
+        var response = await Client.PutAsync("/api/Course/update-course", form);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteCourse_OtherTrainersCourse_ReturnsForbidden()
+    {
+        // Arrange
+        var courseId = await CreateOwnedCourseAsync("delete_owner@example.com");
+
+        // Act
+        await AuthenticateAsync(email: "delete_other@example.com", role: "Trainer");
+        var response = await Client.DeleteAsync($"/api/Course/{courseId}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    // Authenticates as the given trainer and creates a course they own. The
+    // backend stamps the owner from the trainerId JWT claim.
+    private async Task<string> CreateOwnedCourseAsync(string trainerEmail)
+    {
+        await AuthenticateAsync(email: trainerEmail, role: "Trainer");
+
+        var courseId = "COURSE_" + Guid.NewGuid().ToString("N").Substring(0, 8);
+        var response = await Client.PostAsJsonAsync("/api/Course", new CourseCreateDTO
+        {
+            CourseId = courseId,
+            Title = "Payments Auth Test Course",
+            Type = "Online",
+            Category = "Fitness",
+            Price = 100,
+            StartDate = DateTime.Now.AddDays(1),
+            EndDate = DateTime.Now.AddDays(30),
+            Duration = 4,
+            MaxParticipants = 20
+        });
+        Assert.True(response.IsSuccessStatusCode);
+
+        return courseId;
+    }
+
+    private async Task<string> SeedPendingPaymentAsync(string courseId)
+    {
+        using var scope = Factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<GymMarketContext>();
+        var payment = new Payment
+        {
+            PaymentId = Guid.NewGuid().ToString(),
+            CourseId = courseId,
+            StudentId = "STU_PAYMENT_AUTH",
+            PaymentAmount = 100,
+            PaymentStatus = PaymentStatus.Pending,
+            PaymentType = "",
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            PaymentDate = DateTime.UtcNow
+        };
+        context.Payments.Add(payment);
+        await context.SaveChangesAsync();
+        return payment.PaymentId;
+    }
+}

--- a/GymMaket/GymMarket.API.Tests/UserIntegrationTests.cs
+++ b/GymMaket/GymMarket.API.Tests/UserIntegrationTests.cs
@@ -13,51 +13,40 @@ public class UserIntegrationTests : BaseIntegrationTests
     }
 
     [Fact]
-    public async Task GetUserInfo_ReturnsOk()
+    public async Task GetUserInfo_ReturnsOwnProfile()
     {
-        // Arrange
-        await AuthenticateAsync();
-        var email = "userinfo@example.com";
-        var password = "Password123";
-        var signupResp = await Client.PostAsJsonAsync("/api/Accounts/sign-up", new SignUpDto
-        {
-            FullName = "Info User",
-            Email = email,
-            Password = password,
-            ConfirmPassword = password,
-            Role = "Student"
-        });
-        var signupData = await signupResp.Content.ReadFromJsonAsync<SignupResponseDto>();
-        var userId = signupData!.UserId;
+        // Arrange — the endpoint serves the caller's own profile (id from JWT).
+        await AuthenticateAsync(email: "userinfo@example.com");
 
         // Act
-        var response = await Client.GetAsync($"/api/Users/get-user-info/{userId}");
+        var response = await Client.GetAsync("/api/Users/get-user-info");
 
         // Assert
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var info = await response.Content.ReadFromJsonAsync<UserInfoResponseDto>();
+        Assert.Equal(GetTokenClaim("nameid"), info!.UserInfo!.Id);
+        Assert.Equal("userinfo@example.com", info.UserInfo.Email);
     }
 
     [Fact]
-    public async Task UpdateUser_WithValidData_ReturnsSuccess()
+    public async Task UpdateUser_UpdatesTheAuthenticatedUserOnly()
     {
-        // Arrange
-        await AuthenticateAsync();
-        var email = "updateuser@example.com";
-        var password = "Password123";
-        var signupResp = await Client.PostAsJsonAsync("/api/Accounts/sign-up", new SignUpDto
+        // Arrange — a second (potential victim) account exists and is left untouched.
+        await AuthenticateAsync(email: "victim@example.com");
+        var victimUpdate = new UpdateUserDto
         {
-            FullName = "Original Name",
-            Email = email,
-            Password = password,
-            ConfirmPassword = password,
-            Role = "Student"
-        });
-        var signupData = await signupResp.Content.ReadFromJsonAsync<SignupResponseDto>();
-        var userId = signupData!.UserId;
+            FullName = "Victim Original",
+            PhoneNumber = "000",
+            Address = "Victim Address",
+            Avatar = "https://example.com/victim.png"
+        };
+        await Client.PutAsJsonAsync("/api/Users/update-user", victimUpdate);
 
+        // The attacker authenticates and updates "their" profile. The DTO carries no
+        // id, so the change can only ever land on the caller.
+        await AuthenticateAsync(email: "attacker@example.com");
         var updateModel = new UpdateUserDto
         {
-            Id = userId!,
             FullName = "Updated Name",
             PhoneNumber = "123456789",
             Address = "Test Address",
@@ -67,7 +56,19 @@ public class UserIntegrationTests : BaseIntegrationTests
         // Act
         var response = await Client.PutAsJsonAsync("/api/Users/update-user", updateModel);
 
-        // Assert
+        // Assert — the attacker's own profile changed…
         Assert.True(response.IsSuccessStatusCode);
+        var attackerInfo = await Client.GetFromJsonAsync<UserInfoResponseDto>("/api/Users/get-user-info");
+        Assert.Equal("Updated Name", attackerInfo!.UserInfo!.FullName);
+
+        // …and the victim's profile (read as the victim) was not affected.
+        await AuthenticateAsync(email: "victim@example.com");
+        var victimInfo = await Client.GetFromJsonAsync<UserInfoResponseDto>("/api/Users/get-user-info");
+        Assert.Equal("Victim Original", victimInfo!.UserInfo!.FullName);
+    }
+
+    private class UserInfoResponseDto
+    {
+        public GetUserInfoDto? UserInfo { get; set; }
     }
 }

--- a/GymMaket/GymMarket.API/Controllers/ConversationsController.cs
+++ b/GymMaket/GymMarket.API/Controllers/ConversationsController.cs
@@ -25,7 +25,8 @@ namespace GymMarket.API.Controllers
         [HttpPost("create-conversation")]
         public async Task<IActionResult> CreateConversation(CreateConversationDto model)
         {
-            var res = await _conversationRepository.CreateConversation(model);
+            // The sender is always the authenticated user — never trust a client-sent id.
+            var res = await _conversationRepository.CreateConversation(model, GetUserId());
             return StatusCode(res.StatusCode, new { res.Errors, res.Message });
         }
 
@@ -100,6 +101,12 @@ namespace GymMarket.API.Controllers
         [HttpGet("group-members/{conversationId}")]
         public async Task<IActionResult> GetGroupMembers(int conversationId)
         {
+            // Only participants may see who is in a conversation.
+            if (!await _conversationRepository.IsMember(conversationId, GetUserId()))
+            {
+                return Forbid();
+            }
+
             var members = await _conversationRepository.GetGroupMembers(conversationId);
             return Ok(members);
         }
@@ -111,24 +118,32 @@ namespace GymMarket.API.Controllers
             return Ok(users);
         }
 
-        [HttpGet("get-conversation-of-user/{userId}")]
-        public async Task<IActionResult> GetConversationOfUser(string userId)
+        // Conversations, messages and read-state always belong to the authenticated
+        // user — never trust a client-sent id.
+        [HttpGet("get-conversation-of-user")]
+        public async Task<IActionResult> GetConversationOfUser()
         {
-            var conversations = await _conversationRepository.GetConversationOfUser(userId);
+            var conversations = await _conversationRepository.GetConversationOfUser(GetUserId());
             return Ok(conversations);
         }
 
         [HttpGet("get-messages/{conversationId}")]
         public async Task<IActionResult> GetMessages(int conversationId)
         {
+            // Only participants may read a conversation's messages.
+            if (!await _conversationRepository.IsMember(conversationId, GetUserId()))
+            {
+                return Forbid();
+            }
+
             var messages = await _conversationRepository.GetMessages(conversationId);
             return Ok(messages);
         }
 
-        [HttpPost("seen-message/{userId}/{conversationId}")]
-        public async Task<IActionResult> SeenMessage(string userId, int conversationId)
+        [HttpPost("seen-message/{conversationId}")]
+        public async Task<IActionResult> SeenMessage(int conversationId)
         {
-            await _conversationRepository.SeenMessage(userId, conversationId);
+            await _conversationRepository.SeenMessage(GetUserId(), conversationId);
             return Ok();
         }
 

--- a/GymMaket/GymMarket.API/Controllers/CourseController.cs
+++ b/GymMaket/GymMarket.API/Controllers/CourseController.cs
@@ -2,8 +2,10 @@ using AutoMapper;
 using GymMarket.API.DTOs.Course;
 using GymMarket.API.Models;
 using GymMarket.API.Repositories.IRepositories;
+using GymMarket.API.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace GymMarket.API.Controllers
 {
@@ -12,17 +14,58 @@ namespace GymMarket.API.Controllers
     public class CourseController : GenericController<CourseCreateDTO, CourseUpdateDTO, Course, string>
     {
         private readonly ICourseRepository _courseRepository;
+        private readonly ICourseAccessService _courseAccessService;
 
         public CourseController(IGenericRepository<Course, string> repository,
-            IMapper mapper, ICourseRepository courseRepository
+            IMapper mapper, ICourseRepository courseRepository,
+            ICourseAccessService courseAccessService
             ) : base(repository, mapper)
         {
             _courseRepository = courseRepository;
+            _courseAccessService = courseAccessService;
         }
 
         protected override string GetEntityId(Course entity)
         {
             return entity.CourseId;
+        }
+
+        // Creating and modifying courses are staff operations; a trainer may only
+        // touch their own courses (admins may touch any — CanManageCourseAsync).
+
+        [HttpPost]
+        [Authorize(Roles = "Trainer,Admin")]
+        public override async Task<IActionResult> Create([FromBody] CourseCreateDTO createDto)
+        {
+            // A trainer always creates courses they own — never trust a client-sent id.
+            // Admins may create a course on another trainer's behalf.
+            var trainerId = User.FindFirstValue("trainerId");
+            if (!string.IsNullOrEmpty(trainerId))
+            {
+                createDto.TrainerId = trainerId;
+            }
+
+            return await base.Create(createDto);
+        }
+
+        [HttpPut("{id}")]
+        [Authorize(Roles = "Trainer,Admin")]
+        public override async Task<IActionResult> Update(string id, [FromBody] CourseUpdateDTO updateDto)
+        {
+            if (!await _courseAccessService.CanManageCourseAsync(User, id))
+                return Forbid();
+
+            return await base.Update(id, updateDto);
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Roles = "Trainer,Admin")]
+        public override async Task<IActionResult> Delete(string id)
+        {
+            if (!await _courseAccessService.CanManageCourseAsync(User, id))
+                return Forbid();
+
+            return await base.Delete(id);
         }
 
         [AllowAnonymous]
@@ -42,8 +85,12 @@ namespace GymMarket.API.Controllers
         }
 
         [HttpPut("update-course")]
+        [Authorize(Roles = "Trainer,Admin")]
         public async Task<IActionResult> UpdateCourse([FromForm] CourseUpdateDTO courseUpdate)
         {
+            if (!await _courseAccessService.CanManageCourseAsync(User, courseUpdate.CourseId))
+                return Forbid();
+
             var res = await _courseRepository.UpdateCourse(courseUpdate);
             return StatusCode(res.StatusCode, new { res.Message, res.Errors });
         }

--- a/GymMaket/GymMarket.API/Controllers/CourseRegistrationController.cs
+++ b/GymMaket/GymMarket.API/Controllers/CourseRegistrationController.cs
@@ -3,6 +3,7 @@ using GymMarket.API.Models;
 using GymMarket.API.Repositories.IRepositories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace GymMarket.API.Controllers
 {
@@ -22,8 +23,14 @@ namespace GymMarket.API.Controllers
         [HttpPost("register-course")]
         public async Task<IActionResult> RegisterCourse(RegisterCourseDto dto)
         {
+            var studentId = CurrentStudentId();
+            if (string.IsNullOrEmpty(studentId))
+            {
+                return StatusCode(StatusCodes.Status403Forbidden, new { Message = "NOT_A_STUDENT" });
+            }
+
             // Call registration function in repository
-            var result = await _courseRegistrationRepository.RegisterCourseAsync(dto);
+            var result = await _courseRegistrationRepository.RegisterCourseAsync(dto, studentId);
 
             if (result != null)
             {
@@ -36,7 +43,7 @@ namespace GymMarket.API.Controllers
         [HttpPost("cancel-registration/{registrationId}")]
         public async Task<IActionResult> CancelRegistration(string registrationId)
         {
-            var isCancelled = await _courseRegistrationRepository.CancelRegistrationAsync(registrationId);
+            var isCancelled = await _courseRegistrationRepository.CancelRegistrationAsync(registrationId, CurrentStudentId());
             if (isCancelled)
             {
                 return Ok(new { Message = "REGISTRATION_CANCELLED_SUCCESS" });
@@ -47,7 +54,7 @@ namespace GymMarket.API.Controllers
         [HttpPost("initialize-payment/{registrationId}")]
         public async Task<IActionResult> InitializePayment(string registrationId, [FromQuery] decimal initialPayment)
         {
-            var isInitialized = await _courseRegistrationRepository.InitializePaymentAsync(registrationId, initialPayment);
+            var isInitialized = await _courseRegistrationRepository.InitializePaymentAsync(registrationId, initialPayment, CurrentStudentId());
             if (isInitialized)
             {
                 return Ok(new { Message = "PAYMENT_INITIALIZATION_SUCCESS" });
@@ -55,11 +62,18 @@ namespace GymMarket.API.Controllers
             return BadRequest(new { Message = "PAYMENT_INITIALIZATION_FAILED" });
         }
 
-        [HttpGet("get-course-registrations/{studentId}")]
-        public async Task<IActionResult> GetCourseRegistrations(string studentId)
+        [HttpGet("get-course-registrations")]
+        public async Task<IActionResult> GetCourseRegistrations()
         {
-            var list = await _courseRegistrationRepository.GetCourseRegistrations(studentId);
+            var list = await _courseRegistrationRepository.GetCourseRegistrations(CurrentStudentId());
             return Ok(list);
+        }
+
+        // Registrations belong to the authenticated student only — never trust a
+        // client-sent id. The claim is an empty string for non-student users.
+        private string CurrentStudentId()
+        {
+            return User.FindFirstValue("studentId") ?? string.Empty;
         }
     }
 }

--- a/GymMaket/GymMarket.API/Controllers/FoodNutritionController.cs
+++ b/GymMaket/GymMarket.API/Controllers/FoodNutritionController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using GymMarket.API.DTOs.FoodNutritionUser;
 using GymMarket.API.Repositories.IRepositories;
 using Microsoft.AspNetCore.Authorization;
@@ -17,6 +18,12 @@ namespace GymMarket.API.Controllers
             _foodNutritionRepository = foodNutritionRepository;
         }
 
+        // Logs belong to the authenticated user only — never trust a client-sent id.
+        private string CurrentUserId()
+        {
+            return User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+        }
+
         [HttpGet("search-nutrition")]
         public async Task<IActionResult> SearchFoodNutrition([FromQuery] string search)
         {
@@ -24,17 +31,17 @@ namespace GymMarket.API.Controllers
             return Ok(list);
         }
 
-        [HttpGet("get-nutrition-user/{userId}")]
-        public async Task<IActionResult> GetFoodNutritionUser(string userId)
+        [HttpGet("get-nutrition-user")]
+        public async Task<IActionResult> GetFoodNutritionUser()
         {
-            var list = await _foodNutritionRepository.GetFoodNutritionUser(userId);
+            var list = await _foodNutritionRepository.GetFoodNutritionUser(CurrentUserId());
             return Ok(list);
         }
 
         [HttpPost("cal-caloric-value")]
         public async Task<IActionResult> CalCaloricValue(AddFoodNutritionUser model)
         {
-            var result = await _foodNutritionRepository.CalculateCaloric(model);
+            var result = await _foodNutritionRepository.CalculateCaloric(model, CurrentUserId());
             if(result == null)
             {
                 return BadRequest(new { error = "FOOD_NUTRITION_NOT_FOUND" });
@@ -42,10 +49,21 @@ namespace GymMarket.API.Controllers
             return Ok(result);
         }
 
+        [HttpPut("update-foodnutrition-user")]
+        public async Task<IActionResult> UpdateFoodNutritionUser(UpdateFoodNutritionUserDto model)
+        {
+            var result = await _foodNutritionRepository.UpdateFoodNutritionUser(model, CurrentUserId());
+            if (result == null)
+            {
+                return BadRequest(new { error = "FOOD_NUTRITION_USER_NOT_FOUND" });
+            }
+            return Ok(result);
+        }
+
         [HttpDelete("delete-foodnutrition-user")]
         public async Task<IActionResult> DeleteFoodNutritionUser(DeleteFoodNutritionUserDto model)
         {
-            var deleted = await _foodNutritionRepository.DeleteFoodNutritionUser(model);
+            var deleted = await _foodNutritionRepository.DeleteFoodNutritionUser(model, CurrentUserId());
             if(deleted)
             {
                 return Ok(new { message = "Successfully" });

--- a/GymMaket/GymMarket.API/Controllers/MomoPaymentController.cs
+++ b/GymMaket/GymMarket.API/Controllers/MomoPaymentController.cs
@@ -5,6 +5,7 @@ using GymMarket.API.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
+using System.Security.Claims;
 using System.Text;
 
 namespace GymMarket.API.Controllers
@@ -28,7 +29,15 @@ namespace GymMarket.API.Controllers
         [HttpPost("CreatePaymentUrl")]
         public async Task<IActionResult> CreatePaymentUrl([FromBody] CreatePaymentDto dto)
         {
-            var response = await _momoService.CreatePaymentAsync(dto);
+            // The payment is always made by the authenticated student — never trust
+            // a client-sent id, or anyone could mint payment URLs for other students.
+            var studentId = User.FindFirstValue("studentId");
+            if (string.IsNullOrEmpty(studentId))
+            {
+                return StatusCode(StatusCodes.Status403Forbidden, new { error = "NOT_A_STUDENT" });
+            }
+
+            var response = await _momoService.CreatePaymentAsync(dto.CourseId, studentId);
             if (response == null)
             {
                 return NotFound(new { error = "COURSE_NOT_FOUND" });

--- a/GymMaket/GymMarket.API/Controllers/PaymentsController.cs
+++ b/GymMaket/GymMarket.API/Controllers/PaymentsController.cs
@@ -1,5 +1,6 @@
 using GymMarket.API.DTOs.Payment;
 using GymMarket.API.Repositories.IRepositories;
+using GymMarket.API.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -9,20 +10,27 @@ namespace GymMarket.API.Controllers
     [ApiController]
     // Viewing a course's payments and approving/canceling them are trainer/admin actions.
     // Without the role restriction a student could call ok-payment to approve their own
-    // pending payment and study without ever paying.
+    // pending payment and study without ever paying. On top of the role, every action is
+    // scoped to courses the trainer owns (admins may touch any) — otherwise one trainer
+    // could approve or cancel another trainer's payments.
     [Authorize(Roles = "Trainer,Admin")]
     public class PaymentsController : ControllerBase
     {
         private readonly IPaymentRepository _paymentRepository;
+        private readonly ICourseAccessService _courseAccessService;
 
-        public PaymentsController(IPaymentRepository paymentRepository)
+        public PaymentsController(IPaymentRepository paymentRepository, ICourseAccessService courseAccessService)
         {
             _paymentRepository = paymentRepository;
+            _courseAccessService = courseAccessService;
         }
 
         [HttpGet("get-payments-of-course/{courseId}")]
         public async Task<IActionResult> GetPaymentsOfCourse(string courseId)
         {
+            if (!await _courseAccessService.CanManageCourseAsync(User, courseId))
+                return Forbid();
+
             var list = await _paymentRepository.GetPaymentsOfCourse(courseId);
             return Ok(list);
         }
@@ -30,6 +38,9 @@ namespace GymMarket.API.Controllers
         [HttpPost("ok-payment/{paymentId}")]
         public async Task<IActionResult> OkPayment(string paymentId)
         {
+            if (!await CanManagePaymentAsync(paymentId))
+                return Forbid();
+
             var payment = await _paymentRepository.OkPayment(paymentId);
             return Ok(payment);
         }
@@ -37,8 +48,20 @@ namespace GymMarket.API.Controllers
         [HttpPost("cancel-payment")]
         public async Task<IActionResult> CancelPayment(CancelPayment model)
         {
+            if (!await CanManagePaymentAsync(model.PaymentId))
+                return Forbid();
+
             var payment = await _paymentRepository.CancelPayment(model);
             return Ok(payment);
+        }
+
+        private async Task<bool> CanManagePaymentAsync(string paymentId)
+        {
+            var payment = await _paymentRepository.GetByIdAsync(paymentId);
+            if (payment?.CourseId == null)
+                return false;
+
+            return await _courseAccessService.CanManageCourseAsync(User, payment.CourseId);
         }
     }
 }

--- a/GymMaket/GymMarket.API/Controllers/StudentController.cs
+++ b/GymMaket/GymMarket.API/Controllers/StudentController.cs
@@ -4,6 +4,7 @@ using GymMarket.API.Models;
 using GymMarket.API.Repositories.IRepositories;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace GymMarket.API.Controllers
 {
@@ -20,9 +21,13 @@ namespace GymMarket.API.Controllers
             _studentRepository = repository;
         }
 
-        [HttpGet("profile/{userId}")]
-        public async Task<IActionResult> GetProfile(string userId)
+        // A profile contains PII (email, phone, address, health status), so these
+        // endpoints only ever serve the authenticated user's own record — the user
+        // id comes from the JWT, never from the client.
+        [HttpGet("profile")]
+        public async Task<IActionResult> GetProfile()
         {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var result = await _studentRepository.GetStudentProfileByUserId(userId);
             if (!result.Success)
                 return StatusCode(result.StatusCode, result);
@@ -73,9 +78,10 @@ namespace GymMarket.API.Controllers
             return NoContent();
         }
 
-        [HttpGet("by-user/{userId}")]
-        public async Task<IActionResult> GetByUserId(string userId)
+        [HttpGet("by-user")]
+        public async Task<IActionResult> GetByUserId()
         {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var students = await _repository.FindAsync(s => s.UserId == userId);
             var student = students.FirstOrDefault();
             if (student == null)

--- a/GymMaket/GymMarket.API/Controllers/UsersController.cs
+++ b/GymMaket/GymMarket.API/Controllers/UsersController.cs
@@ -2,6 +2,7 @@ using GymMarket.API.DTOs.User;
 using GymMarket.API.Repositories.IRepositories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 
 namespace GymMarket.API.Controllers
 {
@@ -17,9 +18,13 @@ namespace GymMarket.API.Controllers
             _userRepository = userRepository;
         }
 
-        [HttpGet("get-user-info/{userId}")]
-        public async Task<IActionResult> GetUserInfo(string userId)
+        // Returns the caller's own profile (name, email, phone, address). The id
+        // comes from the JWT so one user can't read another's PII — public trainer
+        // contact details are served by the Trainer endpoint instead.
+        [HttpGet("get-user-info")]
+        public async Task<IActionResult> GetUserInfo()
         {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
             var res = await _userRepository.GetUserInfo(userId);
             return StatusCode(res.StatusCode, res);
         }
@@ -27,7 +32,9 @@ namespace GymMarket.API.Controllers
         [HttpPut("update-user")]
         public async Task<IActionResult> UpdateUser(UpdateUserDto model)
         {
-            var res = await _userRepository.UpdateUser(model);
+            // Users may only update their own profile — never trust a client-sent id.
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier)!;
+            var res = await _userRepository.UpdateUser(userId, model);
             return StatusCode(res.StatusCode, res);
         }
     }

--- a/GymMaket/GymMarket.API/DTOs/Course/CourseUpdateDTO.cs
+++ b/GymMaket/GymMarket.API/DTOs/Course/CourseUpdateDTO.cs
@@ -2,11 +2,11 @@
 
 namespace GymMarket.API.DTOs.Course
 {
+    // No TrainerId here: a course never changes owner on update, and the owner is
+    // never taken from the client (see CourseRepository.UpdateCourse).
     public class CourseUpdateDTO
     {
         public string CourseId { get; set; } = string.Empty;
-
-        public string TrainerId { get; set; } = string.Empty;
 
         [StringLength(200)]
         public string? Title { get; set; }

--- a/GymMaket/GymMarket.API/DTOs/CourseRegistration/RegisterCourseDto.cs
+++ b/GymMaket/GymMarket.API/DTOs/CourseRegistration/RegisterCourseDto.cs
@@ -1,10 +1,9 @@
-﻿using Microsoft.AspNetCore.Mvc;
-
-namespace GymMarket.API.DTOs.CourseRegistration
+﻿namespace GymMarket.API.DTOs.CourseRegistration
 {
+    // The registering student is always the authenticated caller (studentId JWT
+    // claim), so the DTO carries no student id.
     public class RegisterCourseDto
     {
         public string CourseId { get; set; } = string.Empty;
-        public string StudentId { get; set; } = string.Empty;
     }
 }

--- a/GymMaket/GymMarket.API/DTOs/FoodNutritionUser/AddFoodNutritionUser.cs
+++ b/GymMaket/GymMarket.API/DTOs/FoodNutritionUser/AddFoodNutritionUser.cs
@@ -4,9 +4,6 @@ namespace GymMarket.API.DTOs.FoodNutritionUser
 {
     public class AddFoodNutritionUser
     {
-        [Required(ErrorMessage = "UserId is required.")]
-        public string UserId { get; set; } = string.Empty;
-
         [Required(ErrorMessage = "FoodNutritionId is required.")]
         public int FoodNutritionId { get; set; }
 
@@ -19,5 +16,8 @@ namespace GymMarket.API.DTOs.FoodNutritionUser
         public double Fat { get; set; }
         public double Sugars { get; set; }
         public double Protein { get; set; }
+
+        public DateOnly? Date { get; set; }
+        public string? MealType { get; set; }
     }
 }

--- a/GymMaket/GymMarket.API/DTOs/FoodNutritionUser/DeleteFoodNutritionUserDto.cs
+++ b/GymMaket/GymMarket.API/DTOs/FoodNutritionUser/DeleteFoodNutritionUserDto.cs
@@ -4,9 +4,6 @@ namespace GymMarket.API.DTOs.FoodNutritionUser
 {
     public class DeleteFoodNutritionUserDto
     {
-        [Required(ErrorMessage = "UserId is required.")]
-        public string UserId { get; set; } = string.Empty;
-
         [Required(ErrorMessage = "FoodNutritionUserId is required.")]
         public int FoodNutritionUserId { get; set; }
     }

--- a/GymMaket/GymMarket.API/DTOs/FoodNutritionUser/UpdateFoodNutritionUserDto.cs
+++ b/GymMaket/GymMarket.API/DTOs/FoodNutritionUser/UpdateFoodNutritionUserDto.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GymMarket.API.DTOs.FoodNutritionUser
+{
+    public class UpdateFoodNutritionUserDto
+    {
+        [Required(ErrorMessage = "FoodNutritionUserId is required.")]
+        public int FoodNutritionUserId { get; set; }
+
+        [Range(0.1, double.MaxValue, ErrorMessage = "Weight must be greater than 0.")]
+        public double Weight { get; set; }
+
+        public DateOnly? Date { get; set; }
+        public string? MealType { get; set; }
+    }
+}

--- a/GymMaket/GymMarket.API/DTOs/Payment/CreatePaymentDto.cs
+++ b/GymMaket/GymMarket.API/DTOs/Payment/CreatePaymentDto.cs
@@ -2,12 +2,11 @@ using System.ComponentModel.DataAnnotations;
 
 namespace GymMarket.API.DTOs.Payment
 {
+    // The paying student is always the authenticated caller (studentId JWT claim),
+    // so the DTO carries no student id.
     public class CreatePaymentDto
     {
         [Required(ErrorMessage = "CourseId is required.")]
         public string CourseId { get; set; } = null!;
-
-        [Required(ErrorMessage = "StudentId is required.")]
-        public string StudentId { get; set; } = null!;
     }
 }

--- a/GymMaket/GymMarket.API/DTOs/User/UpdateUserDto.cs
+++ b/GymMaket/GymMarket.API/DTOs/User/UpdateUserDto.cs
@@ -2,11 +2,10 @@
 
 namespace GymMarket.API.DTOs.User
 {
+    // The user being updated is always the authenticated caller (derived from the
+    // JWT in the controller), so the DTO carries no user id.
     public class UpdateUserDto
     {
-        [Required(ErrorMessage = "Id is required")]
-        public string Id { get; set; } = string.Empty;
-
         [Required(ErrorMessage = "FullName is required")]
         public string FullName { get; set; } = string.Empty;
 

--- a/GymMaket/GymMarket.API/DTOs/UserMessage/CreateConversationDto.cs
+++ b/GymMaket/GymMarket.API/DTOs/UserMessage/CreateConversationDto.cs
@@ -2,11 +2,10 @@
 
 namespace GymMarket.API.DTOs.UserMessage
 {
+    // The sender is always the authenticated caller (derived from the JWT in the
+    // controller), so the DTO only carries the other participant.
     public class CreateConversationDto
     {
-        [Required]
-        public string SenderId { get; set; } = string.Empty;
-
         [Required]
         public string RecieveId { get; set; } = string.Empty;
     }

--- a/GymMaket/GymMarket.API/Data/ModelBuilderExtension.cs
+++ b/GymMaket/GymMarket.API/Data/ModelBuilderExtension.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Identity;
+using GymMarket.API.Models;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 
 namespace GymMarket.API.Data
@@ -7,6 +8,42 @@ namespace GymMarket.API.Data
     {
         public static void SeedData(this ModelBuilder modelBuilder)
         {
+            // Nutritional values are per 100g (CaloricValue in kcal, macros in grams),
+            // matching the weight-based calculation in FoodNutritionRepository.
+            modelBuilder.Entity<FoodNutrition>().HasData(
+                new FoodNutrition { Id = 1, Name = "Apple", CaloricValue = 52, Fat = 0.2, Sugars = 10.4, Protein = 0.3 },
+                new FoodNutrition { Id = 2, Name = "Banana", CaloricValue = 89, Fat = 0.3, Sugars = 12.2, Protein = 1.1 },
+                new FoodNutrition { Id = 3, Name = "Orange", CaloricValue = 47, Fat = 0.1, Sugars = 9.4, Protein = 0.9 },
+                new FoodNutrition { Id = 4, Name = "Strawberries", CaloricValue = 32, Fat = 0.3, Sugars = 4.9, Protein = 0.7 },
+                new FoodNutrition { Id = 5, Name = "Avocado", CaloricValue = 160, Fat = 14.7, Sugars = 0.7, Protein = 2.0 },
+                new FoodNutrition { Id = 6, Name = "Grilled Chicken Breast", CaloricValue = 165, Fat = 3.6, Sugars = 0, Protein = 31.0 },
+                new FoodNutrition { Id = 7, Name = "Lean Beef Steak", CaloricValue = 250, Fat = 15.0, Sugars = 0, Protein = 26.0 },
+                new FoodNutrition { Id = 8, Name = "Baked Salmon", CaloricValue = 208, Fat = 13.0, Sugars = 0, Protein = 20.0 },
+                new FoodNutrition { Id = 9, Name = "Canned Tuna (in Water)", CaloricValue = 116, Fat = 0.8, Sugars = 0, Protein = 25.5 },
+                new FoodNutrition { Id = 10, Name = "Cooked Shrimp", CaloricValue = 99, Fat = 0.3, Sugars = 0, Protein = 24.0 },
+                new FoodNutrition { Id = 11, Name = "Boiled Egg", CaloricValue = 155, Fat = 11.0, Sugars = 1.1, Protein = 13.0 },
+                new FoodNutrition { Id = 12, Name = "Plain Greek Yogurt", CaloricValue = 59, Fat = 0.4, Sugars = 3.2, Protein = 10.0 },
+                new FoodNutrition { Id = 13, Name = "Whole Milk", CaloricValue = 61, Fat = 3.3, Sugars = 5.1, Protein = 3.2 },
+                new FoodNutrition { Id = 14, Name = "Cheddar Cheese", CaloricValue = 403, Fat = 33.0, Sugars = 0.5, Protein = 25.0 },
+                new FoodNutrition { Id = 15, Name = "White Rice (Cooked)", CaloricValue = 130, Fat = 0.3, Sugars = 0.1, Protein = 2.7 },
+                new FoodNutrition { Id = 16, Name = "Brown Rice (Cooked)", CaloricValue = 111, Fat = 0.9, Sugars = 0.4, Protein = 2.6 },
+                new FoodNutrition { Id = 17, Name = "Oatmeal (Cooked)", CaloricValue = 71, Fat = 1.5, Sugars = 0.3, Protein = 2.5 },
+                new FoodNutrition { Id = 18, Name = "Whole Wheat Bread", CaloricValue = 247, Fat = 3.4, Sugars = 6.0, Protein = 13.0 },
+                new FoodNutrition { Id = 19, Name = "Pasta (Cooked)", CaloricValue = 131, Fat = 1.1, Sugars = 0.6, Protein = 5.0 },
+                new FoodNutrition { Id = 20, Name = "Baked Sweet Potato", CaloricValue = 90, Fat = 0.2, Sugars = 6.5, Protein = 2.0 },
+                new FoodNutrition { Id = 21, Name = "Boiled Potato", CaloricValue = 87, Fat = 0.1, Sugars = 0.9, Protein = 1.9 },
+                new FoodNutrition { Id = 22, Name = "Quinoa (Cooked)", CaloricValue = 120, Fat = 1.9, Sugars = 0.9, Protein = 4.4 },
+                new FoodNutrition { Id = 23, Name = "Broccoli", CaloricValue = 34, Fat = 0.4, Sugars = 1.7, Protein = 2.8 },
+                new FoodNutrition { Id = 24, Name = "Spinach", CaloricValue = 23, Fat = 0.4, Sugars = 0.4, Protein = 2.9 },
+                new FoodNutrition { Id = 25, Name = "Carrot", CaloricValue = 41, Fat = 0.2, Sugars = 4.7, Protein = 0.9 },
+                new FoodNutrition { Id = 26, Name = "Almonds", CaloricValue = 579, Fat = 49.9, Sugars = 4.4, Protein = 21.2 },
+                new FoodNutrition { Id = 27, Name = "Peanut Butter", CaloricValue = 588, Fat = 50.0, Sugars = 9.2, Protein = 25.0 },
+                new FoodNutrition { Id = 28, Name = "Lentils (Cooked)", CaloricValue = 116, Fat = 0.4, Sugars = 1.8, Protein = 9.0 },
+                new FoodNutrition { Id = 29, Name = "Black Beans (Cooked)", CaloricValue = 132, Fat = 0.5, Sugars = 0.3, Protein = 8.9 },
+                new FoodNutrition { Id = 30, Name = "Tofu", CaloricValue = 76, Fat = 4.8, Sugars = 0.6, Protein = 8.0 },
+                new FoodNutrition { Id = 31, Name = "Whey Protein Powder", CaloricValue = 412, Fat = 7.0, Sugars = 6.0, Protein = 71.0 },
+                new FoodNutrition { Id = 32, Name = "Dark Chocolate (70%)", CaloricValue = 546, Fat = 31.0, Sugars = 24.0, Protein = 7.9 }
+            );
         }
     }
 }

--- a/GymMaket/GymMarket.API/Migrations/20260612020305_FoodNutritionDateMealTypeAndSeed.Designer.cs
+++ b/GymMaket/GymMarket.API/Migrations/20260612020305_FoodNutritionDateMealTypeAndSeed.Designer.cs
@@ -4,6 +4,7 @@ using GymMarket.API.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace GymMarket.API.Migrations
 {
     [DbContext(typeof(GymMarketContext))]
-    partial class GymMarketContextModelSnapshot : ModelSnapshot
+    [Migration("20260612020305_FoodNutritionDateMealTypeAndSeed")]
+    partial class FoodNutritionDateMealTypeAndSeed
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GymMaket/GymMarket.API/Migrations/20260612020305_FoodNutritionDateMealTypeAndSeed.cs
+++ b/GymMaket/GymMarket.API/Migrations/20260612020305_FoodNutritionDateMealTypeAndSeed.cs
@@ -1,0 +1,100 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GymMarket.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class FoodNutritionDateMealTypeAndSeed : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "Date",
+                table: "FoodNutritionUsers",
+                type: "date",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MealType",
+                table: "FoodNutritionUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            // FoodNutritions may already be populated (script.sql seeds ~870 foods
+            // without explicit ids), so only apply the EF seed to empty databases.
+            // Hand-written instead of the generated InsertData for that reason.
+            migrationBuilder.Sql(@"
+IF NOT EXISTS (SELECT 1 FROM [FoodNutritions])
+BEGIN
+    SET IDENTITY_INSERT [FoodNutritions] ON;
+    INSERT INTO [FoodNutritions] ([Id], [Name], [CaloricValue], [Fat], [Sugars], [Protein])
+    VALUES
+    (1,  N'Apple',                   52,  0.2,  10.4, 0.3),
+    (2,  N'Banana',                  89,  0.3,  12.2, 1.1),
+    (3,  N'Orange',                  47,  0.1,  9.4,  0.9),
+    (4,  N'Strawberries',            32,  0.3,  4.9,  0.7),
+    (5,  N'Avocado',                 160, 14.7, 0.7,  2.0),
+    (6,  N'Grilled Chicken Breast',  165, 3.6,  0,    31.0),
+    (7,  N'Lean Beef Steak',         250, 15.0, 0,    26.0),
+    (8,  N'Baked Salmon',            208, 13.0, 0,    20.0),
+    (9,  N'Canned Tuna (in Water)',  116, 0.8,  0,    25.5),
+    (10, N'Cooked Shrimp',           99,  0.3,  0,    24.0),
+    (11, N'Boiled Egg',              155, 11.0, 1.1,  13.0),
+    (12, N'Plain Greek Yogurt',      59,  0.4,  3.2,  10.0),
+    (13, N'Whole Milk',              61,  3.3,  5.1,  3.2),
+    (14, N'Cheddar Cheese',          403, 33.0, 0.5,  25.0),
+    (15, N'White Rice (Cooked)',     130, 0.3,  0.1,  2.7),
+    (16, N'Brown Rice (Cooked)',     111, 0.9,  0.4,  2.6),
+    (17, N'Oatmeal (Cooked)',        71,  1.5,  0.3,  2.5),
+    (18, N'Whole Wheat Bread',       247, 3.4,  6.0,  13.0),
+    (19, N'Pasta (Cooked)',          131, 1.1,  0.6,  5.0),
+    (20, N'Baked Sweet Potato',      90,  0.2,  6.5,  2.0),
+    (21, N'Boiled Potato',           87,  0.1,  0.9,  1.9),
+    (22, N'Quinoa (Cooked)',         120, 1.9,  0.9,  4.4),
+    (23, N'Broccoli',                34,  0.4,  1.7,  2.8),
+    (24, N'Spinach',                 23,  0.4,  0.4,  2.9),
+    (25, N'Carrot',                  41,  0.2,  4.7,  0.9),
+    (26, N'Almonds',                 579, 49.9, 4.4,  21.2),
+    (27, N'Peanut Butter',           588, 50.0, 9.2,  25.0),
+    (28, N'Lentils (Cooked)',        116, 0.4,  1.8,  9.0),
+    (29, N'Black Beans (Cooked)',    132, 0.5,  0.3,  8.9),
+    (30, N'Tofu',                    76,  4.8,  0.6,  8.0),
+    (31, N'Whey Protein Powder',     412, 7.0,  6.0,  71.0),
+    (32, N'Dark Chocolate (70%)',    546, 31.0, 24.0, 7.9);
+    SET IDENTITY_INSERT [FoodNutritions] OFF;
+END
+");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Matching on Id AND Name so rows that came from script.sql (different
+            // foods at these ids) are never deleted on rollback.
+            migrationBuilder.Sql(@"
+DELETE FROM [FoodNutritions]
+WHERE [Id] <= 32 AND [Name] IN (
+    N'Apple', N'Banana', N'Orange', N'Strawberries', N'Avocado',
+    N'Grilled Chicken Breast', N'Lean Beef Steak', N'Baked Salmon',
+    N'Canned Tuna (in Water)', N'Cooked Shrimp', N'Boiled Egg',
+    N'Plain Greek Yogurt', N'Whole Milk', N'Cheddar Cheese',
+    N'White Rice (Cooked)', N'Brown Rice (Cooked)', N'Oatmeal (Cooked)',
+    N'Whole Wheat Bread', N'Pasta (Cooked)', N'Baked Sweet Potato',
+    N'Boiled Potato', N'Quinoa (Cooked)', N'Broccoli', N'Spinach', N'Carrot',
+    N'Almonds', N'Peanut Butter', N'Lentils (Cooked)', N'Black Beans (Cooked)',
+    N'Tofu', N'Whey Protein Powder', N'Dark Chocolate (70%)');
+");
+
+            migrationBuilder.DropColumn(
+                name: "Date",
+                table: "FoodNutritionUsers");
+
+            migrationBuilder.DropColumn(
+                name: "MealType",
+                table: "FoodNutritionUsers");
+        }
+    }
+}

--- a/GymMaket/GymMarket.API/Models/FoodNutritionUser.cs
+++ b/GymMaket/GymMarket.API/Models/FoodNutritionUser.cs
@@ -18,5 +18,10 @@ namespace GymMarket.API.Models
         public double Fat { get; set; }
         public double Sugars { get; set; }
         public double Protein { get; set; }
+
+        // Nullable so rows logged before these columns existed stay distinguishable
+        // (the client falls back to its localStorage metadata for them).
+        public DateOnly? Date { get; set; }
+        public string? MealType { get; set; }
     }
 }

--- a/GymMaket/GymMarket.API/Repositories/ConversationRepository.cs
+++ b/GymMaket/GymMarket.API/Repositories/ConversationRepository.cs
@@ -25,10 +25,10 @@ namespace GymMarket.API.Repositories
             _notificationRepository = notificationRepository;
         }
 
-        public async Task<ApiResponse> CreateConversation(CreateConversationDto model)
+        public async Task<ApiResponse> CreateConversation(CreateConversationDto model, string senderId)
         {
             var sender = await _context.Users.AsNoTrackingWithIdentityResolution()
-                .Where(u => u.Id == model.SenderId)
+                .Where(u => u.Id == senderId)
                 .FirstOrDefaultAsync();
 
             if (sender == null)
@@ -47,7 +47,7 @@ namespace GymMarket.API.Repositories
 
             var conversationExists = await _context.Conversations
                 .AsNoTrackingWithIdentityResolution()
-                .Where(c => !c.IsGroup && (c.SenderId == model.SenderId || c.SenderId == model.RecieveId) && (c.RecieveId == model.RecieveId || c.RecieveId == model.SenderId))
+                .Where(c => !c.IsGroup && (c.SenderId == senderId || c.SenderId == model.RecieveId) && (c.RecieveId == model.RecieveId || c.RecieveId == senderId))
                 .FirstOrDefaultAsync();
 
             if (conversationExists != null)
@@ -608,6 +608,12 @@ namespace GymMarket.API.Repositories
                 message.SentAt = DateTime.SpecifyKind(message.SentAt, DateTimeKind.Utc);
             }
             return messages;
+        }
+
+        public async Task<bool> IsMember(int conversationId, string userId)
+        {
+            return await _context.ConversationParticipants
+                .AnyAsync(p => p.ConversationId == conversationId && p.UserId == userId);
         }
 
         public async Task<List<int>> GetConversationIdsOfUser(string userId)

--- a/GymMaket/GymMarket.API/Repositories/CourseRegistrationRepository.cs
+++ b/GymMaket/GymMarket.API/Repositories/CourseRegistrationRepository.cs
@@ -21,10 +21,10 @@ namespace GymMarket.API.Repositories
         }
 
         // Registers a course for a student and initializes status as 'Pending Payment'
-        public async Task<CourseRegistration?> RegisterCourseAsync(RegisterCourseDto dto)
+        public async Task<CourseRegistration?> RegisterCourseAsync(RegisterCourseDto dto, string studentId)
         {
             var courseExists = await _context.CourseRegistrations
-                .Where(cr => cr.StudentId == dto.StudentId && cr.CourseId == dto.CourseId)
+                .Where(cr => cr.StudentId == studentId && cr.CourseId == dto.CourseId)
                 .FirstOrDefaultAsync();
 
             if(courseExists != null)
@@ -36,7 +36,7 @@ namespace GymMarket.API.Repositories
             {
                 RegistrationId = Guid.NewGuid().ToString(),
                 CourseId = dto.CourseId,
-                StudentId = dto.StudentId,
+                StudentId = studentId,
                 Status = PaymentStatus.PendingPayment,
                 PaymentStatus = PaymentStatus.NotStarted,
                 CreatedAt = DateTime.UtcNow,
@@ -48,17 +48,21 @@ namespace GymMarket.API.Repositories
 
 
             var course = await _context.Courses.Where(c => c.CourseId == dto.CourseId).FirstOrDefaultAsync();
+            if (course == null)
+            {
+                return null;
+            }
 
             var payment = new Payment()
             {
                 CourseId = dto.CourseId,
-                PaymentAmount = course!.Price + course.AdditionalPrice,
+                PaymentAmount = course.Price + course.AdditionalPrice,
                 CreatedAt = DateTime.UtcNow,
                 PaymentDate = DateTime.UtcNow,
                 PaymentId = Guid.NewGuid().ToString(),
                 PaymentStatus = PaymentStatus.Pending,
                 PaymentType = "",
-                StudentId = dto.StudentId,
+                StudentId = studentId,
                 UpdatedAt = DateTime.UtcNow,
             };
 
@@ -68,12 +72,13 @@ namespace GymMarket.API.Repositories
             return registration;
         }
 
-        // Initializes the payment, setting a timestamp for tracking the 5-minute window
-        public async Task<bool> InitializePaymentAsync(string registrationId, decimal initialPayment)
+        // Initializes the payment, setting a timestamp for tracking the 5-minute window.
+        // Only the student who owns the registration may touch it.
+        public async Task<bool> InitializePaymentAsync(string registrationId, decimal initialPayment, string studentId)
         {
             var registration = await _context.CourseRegistrations.FindAsync(registrationId);
 
-            if (registration == null || registration.PaymentStatus != PaymentStatus.NotStarted)
+            if (registration == null || registration.StudentId != studentId || registration.PaymentStatus != PaymentStatus.NotStarted)
                 return false;
 
             registration.InitialPayment = initialPayment;
@@ -87,12 +92,13 @@ namespace GymMarket.API.Repositories
             return true;
         }
 
-        // Cancels a registration if the payment is not completed within 5 minutes
-        public async Task<bool> CancelRegistrationAsync(string registrationId)
+        // Cancels a registration if the payment is not completed within 5 minutes.
+        // Only the student who owns the registration may cancel it.
+        public async Task<bool> CancelRegistrationAsync(string registrationId, string studentId)
         {
             var registration = await _context.CourseRegistrations.FindAsync(registrationId);
 
-            if (registration == null || registration.PaymentStatus != PaymentStatus.Pending)
+            if (registration == null || registration.StudentId != studentId || registration.PaymentStatus != PaymentStatus.Pending)
                 return false;
 
             // Check if more than 5 minutes have passed since payment initialization

--- a/GymMaket/GymMarket.API/Repositories/CourseRepository.cs
+++ b/GymMaket/GymMarket.API/Repositories/CourseRepository.cs
@@ -57,7 +57,26 @@ namespace GymMarket.API.Repositories
 
         public async Task<ApiResponse> UpdateCourse(CourseUpdateDTO courseUpdateDTO)
         {
+            // The DTO carries no TrainerId; keep the current owner so the full-entity
+            // Update below can't clear (or transfer) course ownership.
+            var currentTrainerId = await _context.Courses
+                .AsNoTracking()
+                .Where(c => c.CourseId == courseUpdateDTO.CourseId)
+                .Select(c => c.TrainerId)
+                .FirstOrDefaultAsync();
+
+            if (currentTrainerId == null)
+            {
+                return new ApiResponse
+                {
+                    Errors = ["COURSE_NOT_FOUND"],
+                    StatusCode = 404,
+                    Success = false
+                };
+            }
+
             var mapEntity = _mapper.Map<CourseUpdateDTO, Course>(courseUpdateDTO);
+            mapEntity.TrainerId = currentTrainerId;
 
             using var transaction = await _context.Database.BeginTransactionAsync();
             try

--- a/GymMaket/GymMarket.API/Repositories/FoodNutritionRepository.cs
+++ b/GymMaket/GymMarket.API/Repositories/FoodNutritionRepository.cs
@@ -16,16 +16,20 @@ namespace GymMarket.API.Repositories
             _context = context;
         }
 
+        private const int MaxSearchResults = 20;
+
         public async Task<List<FoodNutrition>> SearchFoodNutrition(string search)
         {
             var list = await _context.FoodNutritions.AsNoTrackingWithIdentityResolution()
                 .Where(f => f.Name!.ToLower().Contains(search.ToLower()))
+                .OrderBy(f => f.Name)
+                .Take(MaxSearchResults)
                 .ToListAsync();
 
             return list;
         }
 
-        public async Task<FoodNutritionUser?> CalculateCaloric(AddFoodNutritionUser model)
+        public async Task<FoodNutritionUser?> CalculateCaloric(AddFoodNutritionUser model, string userId)
         {
             var foodNutrition = await _context.FoodNutritions
                 .AsNoTrackingWithIdentityResolution()
@@ -50,7 +54,9 @@ namespace GymMarket.API.Repositories
                 Fat = fat,
                 Protein = protein,
                 Sugars = sugars,
-                UserId = model.UserId,
+                UserId = userId,
+                Date = model.Date ?? DateOnly.FromDateTime(DateTime.Today),
+                MealType = model.MealType,
             };
             _context.FoodNutritionUsers.Add(newFoodNutritionUser);
             var r = await _context.SaveChangesAsync();
@@ -70,10 +76,10 @@ namespace GymMarket.API.Repositories
             return list;
         }
 
-        public async Task<bool> DeleteFoodNutritionUser(DeleteFoodNutritionUserDto model)
+        public async Task<bool> DeleteFoodNutritionUser(DeleteFoodNutritionUserDto model, string userId)
         {
             var nutrition = await _context.FoodNutritionUsers
-                .Where(f => f.UserId == model.UserId && f.Id == model.FoodNutritionUserId)
+                .Where(f => f.UserId == userId && f.Id == model.FoodNutritionUserId)
                 .FirstOrDefaultAsync();
 
             if(nutrition == null)
@@ -86,9 +92,37 @@ namespace GymMarket.API.Repositories
             return r > 0;
         }
 
-        public async Task<FoodNutritionUser?> UpdateCalculateCaloric(AddFoodNutritionUser model)
+        public async Task<FoodNutritionUser?> UpdateFoodNutritionUser(UpdateFoodNutritionUserDto model, string userId)
         {
-            return await CalculateCaloric(model);
+            var nutrition = await _context.FoodNutritionUsers
+                .Where(f => f.UserId == userId && f.Id == model.FoodNutritionUserId)
+                .FirstOrDefaultAsync();
+
+            if (nutrition == null || nutrition.Weight <= 0)
+            {
+                return null;
+            }
+
+            // The stored macros scale linearly with weight, so rescale them instead of
+            // re-reading FoodNutritions (the log doesn't keep the source food's id).
+            var factor = model.Weight / nutrition.Weight;
+            nutrition.CaloricValue *= factor;
+            nutrition.Fat *= factor;
+            nutrition.Sugars *= factor;
+            nutrition.Protein *= factor;
+            nutrition.Weight = model.Weight;
+
+            if (model.Date.HasValue)
+            {
+                nutrition.Date = model.Date;
+            }
+            if (!string.IsNullOrWhiteSpace(model.MealType))
+            {
+                nutrition.MealType = model.MealType;
+            }
+
+            await _context.SaveChangesAsync();
+            return nutrition;
         }
     }
 }

--- a/GymMaket/GymMarket.API/Repositories/IRepositories/IConversationRepository.cs
+++ b/GymMaket/GymMarket.API/Repositories/IRepositories/IConversationRepository.cs
@@ -7,7 +7,7 @@ namespace GymMarket.API.Repositories.IRepositories
 {
     public interface IConversationRepository
     {
-        Task<ApiResponse> CreateConversation(CreateConversationDto model);
+        Task<ApiResponse> CreateConversation(CreateConversationDto model, string senderId);
         Task<ApiResponse> CreateGroup(CreateGroupDto model, string creatorId);
         Task<ApiResponse> AddMembers(AddMembersDto model, string actorId);
         Task<ApiResponse> RemoveMember(int conversationId, string userId, string actorId);
@@ -20,6 +20,9 @@ namespace GymMarket.API.Repositories.IRepositories
         Task SeenMessage(string userId, int conversationId);
         Task<UserMessageDto?> SendMessage(SendMessageDto model);
         Task<List<UserMessageDto>> GetMessages(int conversationId);
+        // True when the user participates in the conversation; gate for reading
+        // its messages or member list.
+        Task<bool> IsMember(int conversationId, string userId);
         Task<List<int>> GetConversationIdsOfUser(string userId);
         Task UpdateLastSeen(string userId, DateTime lastSeen);
     }

--- a/GymMaket/GymMarket.API/Repositories/IRepositories/ICourseRegistrationRepository.cs
+++ b/GymMaket/GymMarket.API/Repositories/IRepositories/ICourseRegistrationRepository.cs
@@ -8,9 +8,9 @@ namespace GymMarket.API.Repositories.IRepositories
 {
     public interface ICourseRegistrationRepository : IGenericRepository<CourseRegistration, string>
     {
-        Task<CourseRegistration?> RegisterCourseAsync(RegisterCourseDto dto);
-        Task<bool> InitializePaymentAsync(string registrationId, decimal initialPayment);
-        Task<bool> CancelRegistrationAsync(string registrationId);
+        Task<CourseRegistration?> RegisterCourseAsync(RegisterCourseDto dto, string studentId);
+        Task<bool> InitializePaymentAsync(string registrationId, decimal initialPayment, string studentId);
+        Task<bool> CancelRegistrationAsync(string registrationId, string studentId);
         Task<List<GetCourseDto>> GetCourseRegistrations(string studentId);
     }
 }

--- a/GymMaket/GymMarket.API/Repositories/IRepositories/IFoodNutritionRepository.cs
+++ b/GymMaket/GymMarket.API/Repositories/IRepositories/IFoodNutritionRepository.cs
@@ -6,8 +6,9 @@ namespace GymMarket.API.Repositories.IRepositories
     public interface IFoodNutritionRepository
     {
         Task<List<FoodNutrition>> SearchFoodNutrition(string search);
-        Task<FoodNutritionUser?> CalculateCaloric(AddFoodNutritionUser model);
+        Task<FoodNutritionUser?> CalculateCaloric(AddFoodNutritionUser model, string userId);
         Task<List<FoodNutritionUser>> GetFoodNutritionUser(string userId);
-        Task<bool> DeleteFoodNutritionUser(DeleteFoodNutritionUserDto model);
+        Task<bool> DeleteFoodNutritionUser(DeleteFoodNutritionUserDto model, string userId);
+        Task<FoodNutritionUser?> UpdateFoodNutritionUser(UpdateFoodNutritionUserDto model, string userId);
     }
 }

--- a/GymMaket/GymMarket.API/Repositories/IRepositories/IUserRepository.cs
+++ b/GymMaket/GymMarket.API/Repositories/IRepositories/IUserRepository.cs
@@ -7,6 +7,6 @@ namespace GymMarket.API.Repositories.IRepositories
     public interface IUserRepository
     {
         Task<GetUserInfoResponse> GetUserInfo(string userId);
-        Task<ApiResponse> UpdateUser(UpdateUserDto model);
+        Task<ApiResponse> UpdateUser(string userId, UpdateUserDto model);
     }
 }

--- a/GymMaket/GymMarket.API/Repositories/UserRepository.cs
+++ b/GymMaket/GymMarket.API/Repositories/UserRepository.cs
@@ -37,9 +37,9 @@ namespace GymMarket.API.Repositories
             return new GetUserInfoResponse { Errors = [], StatusCode = 200, Success = true, UserInfo = userInfo };
         }
 
-        public async Task<ApiResponse> UpdateUser(UpdateUserDto model)
+        public async Task<ApiResponse> UpdateUser(string userId, UpdateUserDto model)
         {
-            var user = await _userManager.FindByIdAsync(model.Id);
+            var user = await _userManager.FindByIdAsync(userId);
 
             if (user == null)
             {

--- a/GymMaket/GymMarket.API/Services/MomoService.cs
+++ b/GymMaket/GymMarket.API/Services/MomoService.cs
@@ -22,16 +22,17 @@ namespace GymMarket.API.Services
             _context = context;
         }
 
-        public async Task<MomoCreatePaymentResponseModel?> CreatePaymentAsync(CreatePaymentDto dto)
+        public async Task<MomoCreatePaymentResponseModel?> CreatePaymentAsync(string courseId, string studentId)
         {
-            var course = await _context.Courses.FindAsync(dto.CourseId);
+            var course = await _context.Courses.FindAsync(courseId);
             if (course == null) return null;
 
             string paymentId = Guid.NewGuid().ToString("N");
             double paymentAmount = (double)((course.Price ?? 0) + (course.AdditionalPrice ?? 0));
 
-            // Store studentId and courseId in extraData as JSON
-            var extraData = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new { dto.StudentId, dto.CourseId })));
+            // Store studentId and courseId in extraData as JSON so the signed
+            // callback/IPN can tell which student paid for which course.
+            var extraData = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new { StudentId = studentId, CourseId = courseId })));
 
             var rawData =
                 $"partnerCode={_options.Value.PartnerCode}" +

--- a/gym_market_client/src/app/chat/chat-list/chat-list.component.ts
+++ b/gym_market_client/src/app/chat/chat-list/chat-list.component.ts
@@ -226,10 +226,11 @@ export class ChatListComponent implements OnInit, OnDestroy, AfterViewChecked {
 
 	private getConversations() {
 		patchState(this.loader, { isShow: true });
+		// Stay logged-in gated, but the backend identifies the user from the JWT.
 		const userId = this.userStore.id();
 		if (userId !== null) {
 			this.conversationService
-				.getConversations(userId)
+				.getConversations()
 				.pipe(takeUntilDestroyed(this.destroyRef))
 				.subscribe({
 					next: res => {
@@ -294,11 +295,10 @@ export class ChatListComponent implements OnInit, OnDestroy, AfterViewChecked {
 			if (senderId) {
 				patchState(this.loader, { isShow: true });
 				this.conversationService.createConversation({
-					senderId: senderId,
 					recieveId: targetUserId
 				}).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
 					next: () => {
-						this.conversationService.getConversations(senderId)
+						this.conversationService.getConversations()
 							.pipe(takeUntilDestroyed(this.destroyRef))
 							.subscribe({
 								next: res => {
@@ -391,7 +391,7 @@ export class ChatListComponent implements OnInit, OnDestroy, AfterViewChecked {
 		const userId = this.userStore.id();
 		if (userId !== null) {
 			this.messageService
-				.seenMessage(userId, item.conversationId)
+				.seenMessage(item.conversationId)
 				.pipe(takeUntilDestroyed(this.destroyRef))
 				.subscribe({
 					next: () => {},

--- a/gym_market_client/src/app/chat/conversation.service.ts
+++ b/gym_market_client/src/app/chat/conversation.service.ts
@@ -26,8 +26,9 @@ export class ConversationService {
 		return this.http.post<ApiResponse>(`${this.base}/create-conversation`, model);
 	}
 
-	getConversations(userId: string | null): Observable<Conversation[]> {
-		return this.http.get<Conversation[]>(`${this.base}/get-conversation-of-user/${userId}`);
+	// The backend resolves the user from the JWT.
+	getConversations(): Observable<Conversation[]> {
+		return this.http.get<Conversation[]>(`${this.base}/get-conversation-of-user`);
 	}
 
 	createGroup(model: CreateGroupDto): Observable<ApiResponse> {

--- a/gym_market_client/src/app/chat/message.service.ts
+++ b/gym_market_client/src/app/chat/message.service.ts
@@ -16,9 +16,10 @@ export class MessageService {
 		);
 	}
 
-	seenMessage(userId: string | null, conversationId: number): Observable<void> {
+	// The backend resolves the user from the JWT.
+	seenMessage(conversationId: number): Observable<void> {
 		return this.http.post<void>(
-			`${environment.baseApi}/Conversations/seen-message/${userId}/${conversationId}`,
+			`${environment.baseApi}/Conversations/seen-message/${conversationId}`,
 			{}
 		);
 	}

--- a/gym_market_client/src/app/chat/new-conversation/new-conversation.component.ts
+++ b/gym_market_client/src/app/chat/new-conversation/new-conversation.component.ts
@@ -73,7 +73,7 @@ export class NewConversationComponent implements OnInit {
 		this.submitting = true;
 		this.error = '';
 		this.conversationService
-			.createConversation({ senderId, recieveId: user.id })
+			.createConversation({ recieveId: user.id })
 			.pipe(takeUntilDestroyed(this.destroyRef))
 			.subscribe({
 				next: () => {

--- a/gym_market_client/src/app/core/models/conversation.model.ts
+++ b/gym_market_client/src/app/core/models/conversation.model.ts
@@ -30,8 +30,8 @@ export interface SendMessageDto {
   senderId: string;
 }
 
+// The sender is derived from the JWT on the backend.
 export interface CreateConversationDto {
-  senderId: string;
   recieveId: string;
 }
 

--- a/gym_market_client/src/app/core/models/food-nutrition.model.ts
+++ b/gym_market_client/src/app/core/models/food-nutrition.model.ts
@@ -16,12 +16,25 @@ export interface FoodNutritionUser {
   fat: number;
   sugars: number;
   protein: number;
-  date?: string;
+  // Null on entries logged before the backend persisted these — the
+  // calculator falls back to its localStorage metadata for those.
+  date?: string | null;
+  mealType?: string | null;
 }
 
+// The owning user is derived from the JWT on the backend, so none of the
+// request DTOs carry a userId.
 export interface CaloricValueDto {
-  userId: string | null;
   foodNutritionId: number;
   weight: number;
   foodName: string;
+  date: string;
+  mealType: string;
+}
+
+export interface UpdateFoodNutritionUserDto {
+  foodNutritionUserId: number;
+  weight: number;
+  date: string;
+  mealType: string;
 }

--- a/gym_market_client/src/app/page-agency/update-course/update-course.component.ts
+++ b/gym_market_client/src/app/page-agency/update-course/update-course.component.ts
@@ -183,7 +183,8 @@ export class UpdateCourseComponent implements OnInit {
 		form.append('EndDate', this.model.endDate);
 		form.append('Duration', this.model.duration.toString());
 		form.append('MaxParticipants', this.model.maxParticipants.toString());
-		form.append('TrainerId', this.model.trainerId);
+		// No TrainerId: ownership never changes on update and the backend
+		// keeps the current owner.
 
 		for (let file of this.imagesAdd) form.append('Images', file);
 		for (let file of this.videosAdd) form.append('Videos', file);

--- a/gym_market_client/src/app/page-agency/update-profile/update-profile.component.ts
+++ b/gym_market_client/src/app/page-agency/update-profile/update-profile.component.ts
@@ -58,7 +58,7 @@ export class UpdateProfileComponent implements OnInit {
 		const userId = this.userStore.id();
 		if (userId !== null) {
 			this.userService
-				.getUserInfo(userId)
+				.getUserInfo()
 				.pipe(takeUntilDestroyed(this.destroyRef))
 				.subscribe({
 					next: (res: UserInfoResponse) => {
@@ -136,11 +136,11 @@ export class UpdateProfileComponent implements OnInit {
 	}
 
 	onUpdateUser() {
+		// The backend updates the authenticated user; no id is sent.
 		const user: UpdateUserDto = {
 			address: this.updateForm.controls['address'].value,
 			avatar: this.updateForm.controls['profilePicture'].value,
 			fullName: this.updateForm.controls['fullName'].value,
-			id: this.userStore.id(),
 			phoneNumber: this.updateForm.controls['phoneNumber'].value,
 			status: null,
 		};

--- a/gym_market_client/src/app/page-agency/your-profile/your-profile.component.ts
+++ b/gym_market_client/src/app/page-agency/your-profile/your-profile.component.ts
@@ -48,7 +48,7 @@ export class YourProfileComponent implements OnInit {
 		const userId = this.userStore.id();
 		if (userId !== null) {
 			this.userService
-				.getUserInfo(userId)
+				.getUserInfo()
 				.pipe(takeUntilDestroyed(this.destroyRef))
 				.subscribe({
 					next: (res: UserInfoResponse) => {

--- a/gym_market_client/src/app/pages-client/course-details/course-details.component.ts
+++ b/gym_market_client/src/app/pages-client/course-details/course-details.component.ts
@@ -186,7 +186,7 @@ export class CourseDetailsComponent implements OnInit, OnDestroy {
 			return;
 		}
 		this.courseRegistrationService
-			.getCourses(studentId)
+			.getCourses()
 			.pipe(takeUntilDestroyed(this.destroyRef))
 			.subscribe({
 				next: courses => {
@@ -265,7 +265,7 @@ export class CourseDetailsComponent implements OnInit, OnDestroy {
 		this.courseId = courseId;
 		patchState(this.loader, { isShow: true });
 		this.courseRegistrationService
-			.registerCourse(this.courseId, this.userStore.studentId() ?? '')
+			.registerCourse(this.courseId)
 			.pipe(takeUntilDestroyed(this.destroyRef))
 			.subscribe({
 				next: () => {

--- a/gym_market_client/src/app/pages-client/course-registration.service.ts
+++ b/gym_market_client/src/app/pages-client/course-registration.service.ts
@@ -10,24 +10,25 @@ import { Course } from '../core/models/course.model';
 export class CourseRegistrationService {
 	constructor(private http: HttpClient) {}
 
-	registerCourse(courseId: string, studentId: string): Observable<void> {
+	// The acting student is derived from the JWT on the backend, so no
+	// studentId is ever sent.
+	registerCourse(courseId: string): Observable<void> {
 		return this.http.post<void>(`${environment.baseApi}/CourseRegistration/register-course`, {
 			courseId,
-			studentId,
 		});
 	}
 
 	// The API returns the registered courses (with statusPayment), not registration rows.
-	getCourses(studentId: string): Observable<Course[]> {
+	getCourses(): Observable<Course[]> {
 		return this.http.get<Course[]>(
-			`${environment.baseApi}/CourseRegistration/get-course-registrations/${studentId}`
+			`${environment.baseApi}/CourseRegistration/get-course-registrations`
 		);
 	}
 
-	cancelCourse(courseId: string, studentId: string): Observable<void> {
-		return this.http.post<void>(`${environment.baseApi}/CourseRegistration/cancel-course`, {
-			courseId,
-			studentId,
-		});
+	cancelRegistration(registrationId: string): Observable<void> {
+		return this.http.post<void>(
+			`${environment.baseApi}/CourseRegistration/cancel-registration/${registrationId}`,
+			{}
+		);
 	}
 }

--- a/gym_market_client/src/app/pages-client/course-registration/course-registration.component.ts
+++ b/gym_market_client/src/app/pages-client/course-registration/course-registration.component.ts
@@ -52,7 +52,7 @@ export class CourseRegistrationComponent implements OnInit {
 	private getCouresRegistrations() {
 		patchState(this.loader, { isShow: true });
 		this.courseRegistrationService
-			.getCourses(this.userStore.studentId())
+			.getCourses()
 			.pipe(takeUntilDestroyed(this.destroyRef))
 			.subscribe({
 				next: data => {

--- a/gym_market_client/src/app/pages-client/food-nutrition-calculator/food-nutrition-calculator.component.html
+++ b/gym_market_client/src/app/pages-client/food-nutrition-calculator/food-nutrition-calculator.component.html
@@ -284,9 +284,14 @@
                       <div class="space-y-1.5 mb-2.5">
                         <div class="flex justify-between items-start gap-1">
                           <h5 class="font-black text-gray-900 dark:text-zinc-100 text-sm leading-tight line-clamp-2" title="{{ item.foodName }}">{{ item.foodName }}</h5>
-                          <button (click)="onShowDelete(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500 p-1 flex-shrink-0 -mt-1 -mr-1">
-                            <i class="fa-solid fa-trash-can text-xs"></i>
-                          </button>
+                          <div class="flex items-center flex-shrink-0 -mt-1 -mr-1">
+                            <button (click)="onShowEdit(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-emerald-500 p-1">
+                              <i class="fa-solid fa-pen text-xs"></i>
+                            </button>
+                            <button (click)="onShowDelete(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500 p-1">
+                              <i class="fa-solid fa-trash-can text-xs"></i>
+                            </button>
+                          </div>
                         </div>
                         <p class="text-[11px] md:text-xs text-gray-400 dark:text-zinc-500 font-bold">
                           {{ item.weight.toFixed(0) }}g • F: {{ item.fat.toFixed(0) }}g • P: {{ item.protein.toFixed(0) }}g
@@ -347,9 +352,14 @@
                       <div class="space-y-1.5 mb-2.5">
                         <div class="flex justify-between items-start gap-1">
                           <h5 class="font-black text-gray-900 dark:text-zinc-100 text-sm leading-tight line-clamp-2" title="{{ item.foodName }}">{{ item.foodName }}</h5>
-                          <button (click)="onShowDelete(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500 p-1 flex-shrink-0 -mt-1 -mr-1">
-                            <i class="fa-solid fa-trash-can text-xs"></i>
-                          </button>
+                          <div class="flex items-center flex-shrink-0 -mt-1 -mr-1">
+                            <button (click)="onShowEdit(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-emerald-500 p-1">
+                              <i class="fa-solid fa-pen text-xs"></i>
+                            </button>
+                            <button (click)="onShowDelete(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500 p-1">
+                              <i class="fa-solid fa-trash-can text-xs"></i>
+                            </button>
+                          </div>
                         </div>
                         <p class="text-[11px] md:text-xs text-gray-400 dark:text-zinc-500 font-bold">
                           {{ item.weight.toFixed(0) }}g • F: {{ item.fat.toFixed(0) }}g • P: {{ item.protein.toFixed(0) }}g
@@ -410,9 +420,14 @@
                       <div class="space-y-1.5 mb-2.5">
                         <div class="flex justify-between items-start gap-1">
                           <h5 class="font-black text-gray-900 dark:text-zinc-100 text-sm leading-tight line-clamp-2" title="{{ item.foodName }}">{{ item.foodName }}</h5>
-                          <button (click)="onShowDelete(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500 p-1 flex-shrink-0 -mt-1 -mr-1">
-                            <i class="fa-solid fa-trash-can text-xs"></i>
-                          </button>
+                          <div class="flex items-center flex-shrink-0 -mt-1 -mr-1">
+                            <button (click)="onShowEdit(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-emerald-500 p-1">
+                              <i class="fa-solid fa-pen text-xs"></i>
+                            </button>
+                            <button (click)="onShowDelete(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500 p-1">
+                              <i class="fa-solid fa-trash-can text-xs"></i>
+                            </button>
+                          </div>
                         </div>
                         <p class="text-[11px] md:text-xs text-gray-400 dark:text-zinc-500 font-bold">
                           {{ item.weight.toFixed(0) }}g • F: {{ item.fat.toFixed(0) }}g • P: {{ item.protein.toFixed(0) }}g
@@ -473,9 +488,14 @@
                       <div class="space-y-1.5 mb-2.5">
                         <div class="flex justify-between items-start gap-1">
                           <h5 class="font-black text-gray-900 dark:text-zinc-100 text-sm leading-tight line-clamp-2" title="{{ item.foodName }}">{{ item.foodName }}</h5>
-                          <button (click)="onShowDelete(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500 p-1 flex-shrink-0 -mt-1 -mr-1">
-                            <i class="fa-solid fa-trash-can text-xs"></i>
-                          </button>
+                          <div class="flex items-center flex-shrink-0 -mt-1 -mr-1">
+                            <button (click)="onShowEdit(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-emerald-500 p-1">
+                              <i class="fa-solid fa-pen text-xs"></i>
+                            </button>
+                            <button (click)="onShowDelete(true, item)" class="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500 p-1">
+                              <i class="fa-solid fa-trash-can text-xs"></i>
+                            </button>
+                          </div>
                         </div>
                         <p class="text-[11px] md:text-xs text-gray-400 dark:text-zinc-500 font-bold">
                           {{ item.weight.toFixed(0) }}g • F: {{ item.fat.toFixed(0) }}g • P: {{ item.protein.toFixed(0) }}g
@@ -575,6 +595,59 @@
         Add Log
       </button>
       <button (click)="onShowAddFoodNutrition(false)" class="flex-1 bg-gray-50 dark:bg-zinc-800/80 hover:bg-gray-100 dark:hover:bg-zinc-800 text-gray-500 dark:text-zinc-400 font-extrabold text-sm py-3.5 rounded-2xl transition-all border border-gray-100 dark:border-zinc-700/50 uppercase tracking-wider">
+        Cancel
+      </button>
+    </div>
+  </div>
+</div>
+}
+
+<!-- Modal Dialog: Edit Food Entry -->
+@if(showEdit && foodSelectedToEdit) {
+<div class="modal-backdrop bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+  <div class="modal bg-white dark:bg-zinc-900 rounded-[32px] p-8 w-full max-w-md border border-gray-100 dark:border-zinc-800 shadow-2xl relative" appReveal>
+    <button (click)="onShowEdit(false, null)" class="absolute right-6 top-6 w-9 h-9 rounded-full bg-gray-50 dark:bg-zinc-800/80 flex items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-zinc-200 transition-colors">
+      <i class="fa-solid fa-xmark text-base"></i>
+    </button>
+
+    <h3 class="text-xl font-black text-gray-900 dark:text-white mb-6">Edit Food Entry</h3>
+
+    <!-- Food name (read-only) -->
+    <div class="mb-5">
+      <label class="block text-sm font-black text-gray-400 dark:text-zinc-555 uppercase tracking-wider mb-2">Food Name</label>
+      <div class="form-input bg-gray-50 dark:bg-zinc-800/60 text-gray-500 dark:text-zinc-400 cursor-not-allowed">
+        {{ foodSelectedToEdit.foodName }}
+      </div>
+    </div>
+
+    <!-- Meal Type selector -->
+    <div class="mb-5">
+      <label class="block text-sm font-black text-gray-400 dark:text-zinc-555 uppercase tracking-wider mb-2">Meal Type</label>
+      <select [value]="editMealType" (change)="editMealType = $any($event.target).value" class="form-input bg-white dark:bg-zinc-900">
+        <option value="Breakfast">Breakfast</option>
+        <option value="Lunch">Lunch</option>
+        <option value="Dinner">Dinner</option>
+        <option value="Snacks">Snacks</option>
+      </select>
+    </div>
+
+    <!-- Weight in grams field -->
+    <div class="mb-7">
+      <label class="block text-sm font-black text-gray-400 dark:text-zinc-555 uppercase tracking-wider mb-2">Weight (grams)</label>
+      <input
+        [formControl]="editWeight"
+        type="number"
+        class="form-input"
+        placeholder="e.g. 100"
+        required
+      />
+    </div>
+
+    <div class="flex gap-3">
+      <button (click)="onUpdate()" class="flex-1 bg-emerald-500 hover:bg-emerald-600 text-white font-extrabold text-sm py-3.5 rounded-2xl transition-all shadow-md uppercase tracking-wider">
+        Save Changes
+      </button>
+      <button (click)="onShowEdit(false, null)" class="flex-1 bg-gray-50 dark:bg-zinc-800/80 hover:bg-gray-100 dark:hover:bg-zinc-800 text-gray-500 dark:text-zinc-400 font-extrabold text-sm py-3.5 rounded-2xl transition-all border border-gray-100 dark:border-zinc-700/50 uppercase tracking-wider">
         Cancel
       </button>
     </div>

--- a/gym_market_client/src/app/pages-client/food-nutrition-calculator/food-nutrition-calculator.component.ts
+++ b/gym_market_client/src/app/pages-client/food-nutrition-calculator/food-nutrition-calculator.component.ts
@@ -13,6 +13,7 @@ import {
 	CaloricValueDto,
 	FoodNutrition,
 	FoodNutritionUser,
+	UpdateFoodNutritionUserDto,
 } from '../../core/models/food-nutrition.model';
 import { SEARCH_DEBOUNCE_MS } from '../../utilities/defaults.const';
 import { STORAGE_KEYS } from '../../utilities/storage-keys.const';
@@ -51,6 +52,11 @@ export class FoodNutritionCalculatorComponent implements OnInit {
 	showDelete: boolean = false;
 	foodSelectedToDelete: FoodNutritionUser | null = null;
 	showSettings: boolean = false;
+
+	showEdit: boolean = false;
+	foodSelectedToEdit: FoodNutritionUser | null = null;
+	editWeight: FormControl = new FormControl(0);
+	editMealType: string = 'Breakfast';
 
 	// Redesign Properties
 	selectedDateStr: string = '';
@@ -118,10 +124,9 @@ export class FoodNutritionCalculatorComponent implements OnInit {
 	}
 
 	private getFoodNutritionUser() {
-		const userId = this.userStore.id();
-		if (userId) {
+		if (this.userStore.id()) {
 			this.foodNutritionService
-				.getFoodNutritionUser(userId)
+				.getFoodNutritionUser()
 				.pipe(takeUntilDestroyed(this.destroyRef))
 				.subscribe({
 					next: res => {
@@ -167,16 +172,20 @@ export class FoodNutritionCalculatorComponent implements OnInit {
 		return data ? JSON.parse(data) : {};
 	}
 
-	setMetadata(id: number, date: string, mealType: string) {
-		const metadata = this.getMetadata();
-		metadata[id] = { date, mealType };
-		localStorage.setItem(STORAGE_KEYS.nutritionMetadata, JSON.stringify(metadata));
-	}
-
 	deleteMetadata(id: number) {
 		const metadata = this.getMetadata();
 		delete metadata[id];
 		localStorage.setItem(STORAGE_KEYS.nutritionMetadata, JSON.stringify(metadata));
+	}
+
+	// The backend persists date/mealType on each log; entries created before
+	// that existed fall back to the localStorage metadata.
+	getLogDate(item: FoodNutritionUser, metadata = this.getMetadata()): string | undefined {
+		return item.date ? item.date.slice(0, 10) : metadata[item.id]?.date;
+	}
+
+	getLogMealType(item: FoodNutritionUser, metadata = this.getMetadata()): string {
+		return item.mealType ?? metadata[item.id]?.mealType ?? 'Breakfast';
 	}
 
 	updateFilteredLogs() {
@@ -184,9 +193,9 @@ export class FoodNutritionCalculatorComponent implements OnInit {
 		const meals = ['Breakfast', 'Lunch', 'Dinner', 'Snacks'];
 		let updated = false;
 
-		// Distribute unmapped logs dynamically
+		// Distribute legacy logs with no metadata anywhere dynamically
 		this.foodNutritionUsers.forEach((item, index) => {
-			if (!metadata[item.id]) {
+			if (!item.date && !metadata[item.id]) {
 				const mealType = meals[index % meals.length];
 				metadata[item.id] = {
 					date: this.selectedDateStr,
@@ -201,17 +210,15 @@ export class FoodNutritionCalculatorComponent implements OnInit {
 		}
 
 		// Filter logs for selected date
-		this.filteredLogs = this.foodNutritionUsers.filter(item => {
-			const meta = metadata[item.id];
-			return meta && meta.date === this.selectedDateStr;
-		});
+		this.filteredLogs = this.foodNutritionUsers.filter(
+			item => this.getLogDate(item, metadata) === this.selectedDateStr
+		);
 
 		// Check dot indicators for week days
 		this.weekDays.forEach(day => {
-			day.hasLogs = this.foodNutritionUsers.some(item => {
-				const meta = metadata[item.id];
-				return meta && meta.date === day.fullDate;
-			});
+			day.hasLogs = this.foodNutritionUsers.some(
+				item => this.getLogDate(item, metadata) === day.fullDate
+			);
 		});
 
 		// Distribute logs by meal
@@ -221,7 +228,7 @@ export class FoodNutritionCalculatorComponent implements OnInit {
 		this.snacksLogs = [];
 
 		this.filteredLogs.forEach(item => {
-			const mealType = metadata[item.id]?.mealType || 'Breakfast';
+			const mealType = this.getLogMealType(item, metadata);
 			if (mealType === 'Breakfast') this.breakfastLogs.push(item);
 			else if (mealType === 'Lunch') this.lunchLogs.push(item);
 			else if (mealType === 'Dinner') this.dinnerLogs.push(item);
@@ -288,10 +295,11 @@ export class FoodNutritionCalculatorComponent implements OnInit {
 		if (!this.selectedFood) return;
 
 		const model: CaloricValueDto = {
-			userId: this.userStore.id(),
 			foodNutritionId: this.selectedFood.id,
 			weight: this.weight.value,
 			foodName: this.selectedFood.name,
+			date: this.selectedDateStr,
+			mealType: this.selectedMealType,
 		};
 
 		patchState(this.loader, { isShow: true });
@@ -302,9 +310,6 @@ export class FoodNutritionCalculatorComponent implements OnInit {
 				next: res => {
 					this.showAddFood = false;
 					patchState(this.loader, { isShow: false });
-					
-					// Save local metadata
-					this.setMetadata(res.id, this.selectedDateStr, this.selectedMealType);
 
 					this.foodNutritionUsers.push(res);
 					patchState(this.notice, { isShow: true, message: 'Added successfully' });
@@ -333,13 +338,63 @@ export class FoodNutritionCalculatorComponent implements OnInit {
 		this.foodSelectedToDelete = food;
 	}
 
+	onShowEdit(flag: boolean, food: FoodNutritionUser | null) {
+		this.showEdit = flag;
+		this.foodSelectedToEdit = food;
+		if (food) {
+			this.editWeight.setValue(food.weight);
+			this.editMealType = this.getLogMealType(food);
+		}
+	}
+
+	onUpdate() {
+		if (!this.foodSelectedToEdit) return;
+
+		const item = this.foodSelectedToEdit;
+		const model: UpdateFoodNutritionUserDto = {
+			foodNutritionUserId: item.id,
+			weight: this.editWeight.value,
+			date: this.getLogDate(item) ?? this.selectedDateStr,
+			mealType: this.editMealType,
+		};
+
+		patchState(this.loader, { isShow: true });
+		this.foodNutritionService
+			.updateFoodNutritionUser(model)
+			.pipe(takeUntilDestroyed(this.destroyRef))
+			.subscribe({
+				next: res => {
+					patchState(this.loader, { isShow: false });
+					this.showEdit = false;
+
+					// The backend now owns this entry's date/meal type
+					this.deleteMetadata(item.id);
+
+					this.foodNutritionUsers = this.foodNutritionUsers.map(x =>
+						x.id === res.id ? res : x
+					);
+					this.foodSelectedToEdit = null;
+					patchState(this.notice, { isShow: true, message: 'Updated successfully' });
+					this.updateFilteredLogs();
+					this.cdr.markForCheck();
+				},
+				error: () => {
+					patchState(this.errorModal, {
+						isShow: true,
+						errors: ['An error occurred. Please try again.'],
+					});
+					patchState(this.loader, { isShow: false });
+					this.showEdit = false;
+				},
+			});
+	}
+
 	onDelete() {
 		if (!this.foodSelectedToDelete) return;
 
 		const idToDelete = this.foodSelectedToDelete.id;
 		this.foodNutritionService
 			.deleteFoodNutritionUser({
-				userId: this.userStore.id() ?? '',
 				foodNutritionUserId: idToDelete,
 			})
 			.pipe(takeUntilDestroyed(this.destroyRef))

--- a/gym_market_client/src/app/pages-client/food-nutrition.service.ts
+++ b/gym_market_client/src/app/pages-client/food-nutrition.service.ts
@@ -6,6 +6,7 @@ import {
 	CaloricValueDto,
 	FoodNutrition,
 	FoodNutritionUser,
+	UpdateFoodNutritionUserDto,
 } from '../core/models/food-nutrition.model';
 
 @Injectable({
@@ -20,9 +21,9 @@ export class FoodNutritionService {
 		);
 	}
 
-	getFoodNutritionUser(userId: string | null): Observable<FoodNutritionUser[]> {
+	getFoodNutritionUser(): Observable<FoodNutritionUser[]> {
 		return this.http.get<FoodNutritionUser[]>(
-			`${environment.baseApi}/FoodNutrition/get-nutrition-user/${userId}`
+			`${environment.baseApi}/FoodNutrition/get-nutrition-user`
 		);
 	}
 
@@ -33,10 +34,17 @@ export class FoodNutritionService {
 		);
 	}
 
-	deleteFoodNutritionUser(model: { userId: string; foodNutritionUserId: number }): Observable<void> {
-		return this.http.post<void>(
-			`${environment.baseApi}/FoodNutrition/delete-foodnutrition-user`,
+	updateFoodNutritionUser(model: UpdateFoodNutritionUserDto): Observable<FoodNutritionUser> {
+		return this.http.put<FoodNutritionUser>(
+			`${environment.baseApi}/FoodNutrition/update-foodnutrition-user`,
 			model
+		);
+	}
+
+	deleteFoodNutritionUser(model: { foodNutritionUserId: number }): Observable<void> {
+		return this.http.delete<void>(
+			`${environment.baseApi}/FoodNutrition/delete-foodnutrition-user`,
+			{ body: model }
 		);
 	}
 }

--- a/gym_market_client/src/app/pages-client/student.service.ts
+++ b/gym_market_client/src/app/pages-client/student.service.ts
@@ -14,12 +14,14 @@ export class StudentService {
 		return this.http.get<Student>(`${environment.baseApi}/student/${studentId}`);
 	}
 
-	getStudentInfoByUserId(userId: string): Observable<Student> {
-		return this.http.get<Student>(`${environment.baseApi}/student/by-user/${userId}`);
+	// Both endpoints only ever serve the authenticated user's own record (the
+	// backend resolves the user from the JWT), so no userId is sent.
+	getOwnStudentInfo(): Observable<Student> {
+		return this.http.get<Student>(`${environment.baseApi}/student/by-user`);
 	}
 
-	getStudentProfile(userId: string): Observable<StudentProfileResponse> {
-		return this.http.get<StudentProfileResponse>(`${environment.baseApi}/student/profile/${userId}`);
+	getOwnStudentProfile(): Observable<StudentProfileResponse> {
+		return this.http.get<StudentProfileResponse>(`${environment.baseApi}/student/profile`);
 	}
 
 	updateStudentProfile(model: UpdateStudentProfileDto, studentId: string): Observable<void> {

--- a/gym_market_client/src/app/pages-client/trainer-details/trainer-details.component.html
+++ b/gym_market_client/src/app/pages-client/trainer-details/trainer-details.component.html
@@ -1,4 +1,4 @@
-@if (trainerInfo && userInfo) {
+@if (trainerInfo) {
   <div class="trainer-dashboard container">
     <!-- Top banner matching mockup: "ONLINE COURSE / Sharpen Your Skills with Professional Online Courses" -->
     <div class="dashboard-banner">
@@ -9,14 +9,10 @@
           <p class="banner-subtitle">{{trainerInfo.bio || 'Transform your health with professional fitness and wellness guidance.'}}</p>
           
           <div class="banner-info-chips">
-            <span class="chip">
-              <i class="fa-solid fa-envelope"></i>
-              <span>{{userInfo.email}}</span>
-            </span>
-            @if (userInfo.address) {
+            @if (trainerInfo.email) {
               <span class="chip">
-                <i class="fa-solid fa-location-dot"></i>
-                <span>{{userInfo.address}}</span>
+                <i class="fa-solid fa-envelope"></i>
+                <span>{{trainerInfo.email}}</span>
               </span>
             }
             <span class="chip">

--- a/gym_market_client/src/app/pages-client/trainer-details/trainer-details.component.ts
+++ b/gym_market_client/src/app/pages-client/trainer-details/trainer-details.component.ts
@@ -3,7 +3,6 @@ import { TrainerService } from '../../page-agency/trainer.service';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { patchState } from '@ngrx/signals';
 import { LoaderModalStore } from '../../stores/loader.store';
-import { UserService } from '../../user/user.service';
 import { CourseAgencyService } from '../../page-agency/course-agency.service';
 import { ConversationService } from '../../chat/conversation.service';
 import { UserStore } from '../../stores/user.store';
@@ -11,7 +10,6 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Trainer } from '../../core/models/trainer.model';
 import { Course } from '../../core/models/course.model';
 import { CommonModule } from '@angular/common';
-import { UserInfo } from '../../core/models/auth.model';
 import { DEFAULT_AVATAR_URL } from '../../utilities/defaults.const';
 
 @Component({
@@ -27,7 +25,6 @@ export class TrainerDetailsComponent implements OnInit {
 	private cdr = inject(ChangeDetectorRef);
 	trainerId: string = '';
 	trainerInfo: Trainer | null = null;
-	userInfo: UserInfo | null = null;
 	coursesOfTrainer: Course[] = [];
 	otherTrainers: Trainer[] = [];
 	followedTrainersMap: { [id: string]: boolean } = {};
@@ -38,7 +35,6 @@ export class TrainerDetailsComponent implements OnInit {
 	constructor(
 		private trainerService: TrainerService,
 		private activatedRoute: ActivatedRoute,
-		private userService: UserService,
 		private courseAgencyService: CourseAgencyService,
 		private conversationService: ConversationService,
 		private router: Router
@@ -108,24 +104,11 @@ export class TrainerDetailsComponent implements OnInit {
 					if (!this.trainerInfo.profilePicture) {
 						this.trainerInfo.profilePicture = DEFAULT_AVATAR_URL;
 					}
-					this.getUserInfo(res.userId);
 					patchState(this.loader, { isShow: false });
 					this.cdr.markForCheck();
 				},
 				error: () => {
 					patchState(this.loader, { isShow: false });
-				},
-			});
-	}
-
-	private getUserInfo(userId: string) {
-		this.userService
-			.getUserInfo(userId)
-			.pipe(takeUntilDestroyed(this.destroyRef))
-			.subscribe({
-				next: res => {
-					this.userInfo = res.userInfo;
-					this.cdr.markForCheck();
 				},
 			});
 	}
@@ -152,7 +135,6 @@ export class TrainerDetailsComponent implements OnInit {
 		}
 
 		const model = {
-			senderId: senderId,
 			recieveId: this.trainerInfo.userId,
 		};
 

--- a/gym_market_client/src/app/pages-client/update-profile/update-profile.component.ts
+++ b/gym_market_client/src/app/pages-client/update-profile/update-profile.component.ts
@@ -106,7 +106,7 @@ export class UpdateProfileComponent implements OnInit {
 		const userId = this.userStore.id();
 		if (userId) {
 			this.userService
-				.getUserInfo(userId)
+				.getUserInfo()
 				.pipe(takeUntilDestroyed(this.destroyRef))
 				.subscribe({
 					next: (res) => {
@@ -145,7 +145,7 @@ export class UpdateProfileComponent implements OnInit {
 			const userId = this.userStore.id();
 			if (userId) {
 				this.studentService
-					.getStudentInfoByUserId(userId)
+					.getOwnStudentInfo()
 					.pipe(takeUntilDestroyed(this.destroyRef))
 					.subscribe({
 						next: res => {
@@ -243,11 +243,11 @@ export class UpdateProfileComponent implements OnInit {
 
 	onUpdateUser() {
 		const formValues = this.updateForm.getRawValue();
+		// The backend updates the authenticated user; no id is sent.
 		const user: UpdateUserDto = {
 			address: formValues.address,
 			avatar: formValues.profilePicture,
 			fullName: formValues.fullName,
-			id: this.userStore.id(),
 			phoneNumber: formValues.phoneNumber,
 			status: null,
 		};

--- a/gym_market_client/src/app/pages-client/your-profile/your-profile.component.ts
+++ b/gym_market_client/src/app/pages-client/your-profile/your-profile.component.ts
@@ -34,11 +34,11 @@ export class YourProfileComponent implements OnInit {
 	}
 
 	private loadProfile() {
-		const userId = this.userStore.id();
-		if (!userId) return;
+		// Stay logged-in gated, but the backend identifies the user from the JWT.
+		if (!this.userStore.id()) return;
 
 		this.studentService
-			.getStudentProfile(userId)
+			.getOwnStudentProfile()
 			.pipe(takeUntilDestroyed(this.destroyRef))
 			.subscribe({
 				next: res => {

--- a/gym_market_client/src/app/user/models/update-user.dto.ts
+++ b/gym_market_client/src/app/user/models/update-user.dto.ts
@@ -1,5 +1,5 @@
+// The user being updated is derived from the JWT on the backend.
 export interface UpdateUserDto {
-	id: string | null;
 	fullName: string;
 	address: string;
 	avatar: string;

--- a/gym_market_client/src/app/user/user.service.ts
+++ b/gym_market_client/src/app/user/user.service.ts
@@ -11,9 +11,11 @@ import { UserInfoResponse } from '../core/models/auth.model';
 export class UserService {
 	constructor(private http: HttpClient) {}
 
-	getUserInfo(userId: string | null): Observable<UserInfoResponse> {
+	// Returns the authenticated caller's own profile; the backend resolves the
+	// user from the JWT, so no id is sent.
+	getUserInfo(): Observable<UserInfoResponse> {
 		return this.http.get<UserInfoResponse>(
-			`${environment.baseApi}/users/get-user-info/${userId}`
+			`${environment.baseApi}/users/get-user-info`
 		);
 	}
 


### PR DESCRIPTION
Several authenticated endpoints trusted a client-sent identity (userId, studentId, senderId, trainerId) from the request body, route, or query. Derive identity from JWT claims instead:

- Users: update-user and get-user-info are now self-only
- CourseRegistration & Momo payment: use the studentId claim
- Conversations: sender from JWT; gate messages/members on membership
- Student profile: self-only (PII)
- Course: gate update/delete on ownership; drop TrainerId from update DTO so ownership can't be transferred
- Payments: scope view/approve/cancel to the trainer's own courses

Update Angular services/components to stop sending ids, and add cross-account authorization tests. 46/46 backend tests pass.